### PR TITLE
[HC-13] Add a table for certificates and an endpoint for including them in the database.

### DIFF
--- a/backend/models/certificates.js
+++ b/backend/models/certificates.js
@@ -1,0 +1,39 @@
+module.exports = (sequelize, DataTypes) => {
+  const Certificate = sequelize.define("Certificate", {
+    title: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    issueDate: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    studentId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: "Students", // table name
+        key: "id"
+      },
+      onDelete: "CASCADE"
+    },
+    issuerId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: "Issuers", // table name
+        key: "id"
+      },
+      onDelete: "CASCADE"
+    }
+  });
+
+  Certificate.associate = (models) => {
+    // A certificate belongs to an student
+    Certificate.belongsTo(models.Student, { foreignKey: 'studentId' });
+    // A certificate is issued by an Issuer
+    Certificate.belongsTo(models.Issuer, { foreignKey: 'issuerId' });
+  };
+
+  return Certificate;
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -19,5 +19,6 @@ db.sequelize = sequelize;
 db.Student = require("./students")(sequelize, DataTypes);
 db.Issuer = require("./issuers")(sequelize, DataTypes);
 db.Recruiter = require("./recruiters")(sequelize, DataTypes);
+db.Certificate = require("./certificates")(sequelize, DataTypes);
 
 module.exports = db;

--- a/backend/models/issuers.js
+++ b/backend/models/issuers.js
@@ -32,5 +32,9 @@ module.exports = (sequelize, DataTypes) => {
     issuer.passwordHash = await bcrypt.hash(issuer.passwordHash, salt);
   });
 
+  Issuer.associate = (models) => {
+    Issuer.hasMany(models.Certificate, { foreignKey: 'issuerId' });
+  }
+
   return Issuer;
 };

--- a/backend/models/students.js
+++ b/backend/models/students.js
@@ -4,17 +4,14 @@ module.exports = (sequelize, DataTypes) => {
   const Student = sequelize.define("Student", {
     name: {
       type: DataTypes.STRING,
-      unique: true,
       allowNull: false
     },
     lastName: {
       type: DataTypes.STRING,
-      unique: true,
       allowNull: false
     },
     age: {
       type: DataTypes.INTEGER,
-      unique: true,
       allowNull: false
     },
     email: {
@@ -41,6 +38,11 @@ module.exports = (sequelize, DataTypes) => {
     const salt = await bcrypt.genSalt(10);
     student.passwordHash = await bcrypt.hash(student.passwordHash, salt);
   });
+
+  // Relate students with certificates
+  Student.associate = (models) => {
+    Student.hasMany(models.Certificate, { foreignKey: 'studentId' });
+  }
 
   return Student;
 };

--- a/backend/routes/certificates.js
+++ b/backend/routes/certificates.js
@@ -8,6 +8,8 @@ const pinata = new PinataSDK({
   pinataGateway: process.env.GATEWAY_URL,
 });
 
+const { Certificate, Student, Issuer } = require("../models");
+
 const defaultCertificateCID = "bafybeibmeqeia5ta52vxbapor5mkens2uwau2xsy6oetrf6prlcfssm5le";
 
 // POST /api/certificates: Upload certificate metadata to Pinata
@@ -48,6 +50,42 @@ router.get("/:cid", async (req, res) => {
   } catch (error) {
     console.error(error);
     res.status(404).json({ error: "Metadata not found" });
+  }
+});
+
+// POST /api/certificates/database
+router.post("/database", async (req, res) => {
+  try {
+    const { title, issueDate, studentId, issuerId } = req.body;
+
+    // 1. Check if student exists
+    const student = await Student.findByPk(studentId);
+    if (!student) {
+      return res.status(404).json({ error: "Student not found" });
+    }
+
+    // 2. Check if issuer exists
+    const issuer = await Issuer.findByPk(issuerId);
+    if (!issuer) {
+      return res.status(404).json({ error: "Issuer not found" });
+    }
+
+    // 3. Create certificate
+    const certificate = await Certificate.create({
+      title,
+      issueDate,
+      studentId,
+      issuerId
+    });
+
+    res.status(201).json({
+      message: "Certificate created successfully",
+      certificate
+    });
+
+  } catch (error) {
+    console.error("Error creating certificate:", error);
+    res.status(500).json({ error: "Internal server error" });
   }
 });
 


### PR DESCRIPTION
# Add Create Certificate Endpoint and Model Associations
## Description
This PR introduces functionality for creating new certificates linked to existing students and issuers in the system.  
The update includes:
- **New `Certificate` model** with fields:
  - `title` (string, required)
  - `issueDate` (date, required)
  - `studentId` (FK → `Student.id`)
  - `issuerId` (FK → `Issuer.id`)
- **Model associations**:
  - `Student.hasMany(Certificate)`
  - `Issuer.hasMany(Certificate)`
  - `Certificate.belongsTo(Student)`
  - `Certificate.belongsTo(Issuer)`
- **POST `/api/certificate/database` endpoint**:
  - Validates that both student and issuer exist before creating.
  - Creates a new certificate record with the provided details.
  - Returns the created certificate object.
- Updated Sequelize `sync` logic to ensure tables are created in the correct order.