### PR TITLE
fix(security): add authenticate middleware to students and issuers routes

### DIFF
--- a/backend/routes/issuers.js
+++ b/backend/routes/issuers.js
@@ -3,9 +3,10 @@ const express = require("express");
 const router = express.Router();
 const { Issuer, Student, User, Certificate } = require("../models");
 const { authorizeIssuer } = require("../services/authorizeIssuer.js");
+const { authenticate } = require("../middleware/auth");
 
 // GET /api/issuers
-router.get("/", async (req, res) => {
+router.get("/", authenticate, async (req, res) => {
   try {
     const issuers = await Issuer.findAll({
       include: [{
@@ -46,7 +47,7 @@ router.post("/authorize", async (req, res) => {
 });
 //|| !certificate_hash || !token_id)
 // POST /api/issuers/mint
-router.post("/mint", async (req, res) => {
+router.post("/mint", authenticate, async (req, res) => {
   try {
     const {
       studentWalletAddress,
@@ -81,7 +82,7 @@ router.post("/mint", async (req, res) => {
 });
 
 // GET /api/issuers/:wallet_address
-router.get("/:wallet_address", async (req, res) => {
+router.get("/:wallet_address", authenticate, async (req, res) => {
   try {
     const { wallet_address } = req.params;
 
@@ -119,7 +120,7 @@ router.get("/:wallet_address", async (req, res) => {
 });
 
 // PUT /api/issuers/:wallet_address
-router.put("/:wallet_address", async (req, res) => {
+router.put("/:wallet_address", authenticate, async (req, res) => {
   try {
     const { wallet_address } = req.params;
     const { organization_name } = req.body;
@@ -138,7 +139,7 @@ router.put("/:wallet_address", async (req, res) => {
 });
 
 // POST /api/issuers/increment-certificates
-router.post("/increment-certificates", async (req, res) => {
+router.post("/increment-certificates", authenticate, async (req, res) => {
   try {
     const { issuerWallet } = req.body;
     if (!issuerWallet) return res.status(400).json({ error: "issuerWallet required" });

--- a/backend/routes/students.js
+++ b/backend/routes/students.js
@@ -2,9 +2,10 @@
 const express = require("express");
 const router = express.Router();
 const { Student, User, Certificate } = require("../models");
+const { authenticate } = require("../middleware/auth");
 
 // GET /api/students
-router.get("/", async (req, res) => {
+router.get("/", authenticate, async (req, res) => {
   try {
     const students = await Student.findAll({
       include: [
@@ -39,7 +40,7 @@ router.get("/", async (req, res) => {
 
 
 // GET /api/students/:wallet_address
-router.get("/:wallet_address", async (req, res) => {
+router.get("/:wallet_address", authenticate, async (req, res) => {
   try {
     const { wallet_address } = req.params;
 
@@ -84,7 +85,7 @@ router.get("/:wallet_address", async (req, res) => {
 
 
 // PUT /api/students/:wallet_address
-router.put("/:wallet_address", async (req, res) => {
+router.put("/:wallet_address", authenticate, async (req, res) => {
   try {
     const { wallet_address } = req.params;
     const { field_of_study } = req.body;

--- a/frontend/src/hooks/useCreateCertificate.ts
+++ b/frontend/src/hooks/useCreateCertificate.ts
@@ -34,9 +34,14 @@ export const useCreateCertificate = () => {
         imageCID: data.imageUri.replace('ipfs://', '') // Limpiamos el prefijo si lo tiene
       };
 
-      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/certificates`, { 
+      const token = localStorage.getItem('authToken');
+      if (!token) return false;
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/certificates`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
         body: JSON.stringify(payload),
       });
 

--- a/frontend/src/pages/EducatorDashboard.tsx
+++ b/frontend/src/pages/EducatorDashboard.tsx
@@ -113,7 +113,11 @@ const EducatorDashboard = () => {
     // Fetch Talents
     const fetchTalents = async () => {
       try {
-        const response = await fetch(`${import.meta.env.VITE_API_URL}/api/students`);
+        const token = localStorage.getItem('authToken');
+        if (!token) return;
+        const response = await fetch(`${import.meta.env.VITE_API_URL}/api/students`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
         if (response.ok) {
           const data = await response.json();
           if (data.students) {

--- a/frontend/src/utils/mintCertificate.jsx
+++ b/frontend/src/utils/mintCertificate.jsx
@@ -806,9 +806,14 @@ function App() {
         }
 
         try {
+            const token = localStorage.getItem('authToken');
+            if (!token) return;
             const response = await fetch(`${import.meta.env.VITE_API_URL}/api/issuers/mint`, {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers: {
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${token}`
+                },
                 body: JSON.stringify({
                     walletTalent,
                     nameTalent,

--- a/frontend/src/utils/web3Service.ts
+++ b/frontend/src/utils/web3Service.ts
@@ -778,10 +778,14 @@ export const web3Service = {
             const receipt = await tx.wait();
             console.log("Transaction confirmed:", tx.hash);
 
+            const token = localStorage.getItem('authToken');
+            if (!token) return false;
+
             await fetch(`${import.meta.env.VITE_API_URL}/api/issuers/increment-certificates`, {
                 method: "POST",
                 headers: {
-                    "Content-Type": "application/json"
+                    "Content-Type": "application/json",
+                    "Authorization": `Bearer ${token}`
                 },
                 body: JSON.stringify({
                     issuerWallet:issuerWallet.toLowerCase()
@@ -801,7 +805,6 @@ export const web3Service = {
 
             // Guardar en la base de datos
             const issue_date = new Date().toISOString().split('T')[0];
-            const token = localStorage.getItem('authToken');
             const response = await fetch(`${import.meta.env.VITE_API_URL}/api/certificates/database`, {
                 method: "POST",
                 headers: {


### PR DESCRIPTION
## Summary

Apply the existing `authenticate` middleware from `backend/middleware/auth.js` to sensitive endpoints in `backend/routes/students.js` and `backend/routes/issuers.js`, and update the frontend to send the `Authorization` header on the affected calls following the project's existing pattern.

## Backend changes

### `backend/routes/students.js`
- Import `authenticate` from `middleware/auth.js`
- Apply to `GET /`, `GET /:wallet_address`, `PUT /:wallet_address`

### `backend/routes/issuers.js`
- Import `authenticate` from `middleware/auth.js`
- Apply to `GET /`, `POST /mint`, `GET /:wallet_address`, `PUT /:wallet_address`, `POST /increment-certificates`

## Frontend changes

All four files follow the existing standard pattern already used in `RecruiterDashboard.tsx` and `TalentDetailDashboard.tsx` (read `authToken` from `localStorage`, add `Authorization: Bearer <token>` to the fetch headers):

- `frontend/src/pages/EducatorDashboard.tsx` — `GET /api/students`
- `frontend/src/hooks/useCreateCertificate.ts` — `POST /api/certificates`
- `frontend/src/utils/mintCertificate.jsx` — `POST /api/issuers/mint`
- `frontend/src/utils/web3Service.ts` — `POST /api/issuers/increment-certificates`