### PR TITLE
feat(harjoot): integration implementation (WIP — multi-phase)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ skills-lock.json
 AGENTS.md
 PRODUCT.md
 /documents
+*:Zone.Identifier

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,87 @@
+# backend/.env.example
+#
+# Copy this file to backend/.env and fill in the values you need.
+# Variables marked REQUIRED throw on server startup if missing — the server
+# will not boot. Optional variables have sensible defaults inline.
+#
+# DO NOT COMMIT backend/.env.
+
+# =============================================================================
+# Server runtime
+# =============================================================================
+NODE_ENV=development
+PORT=3001
+GLOBAL_RATE_LIMIT_MAX=100
+
+# =============================================================================
+# Authentication (JWT + refresh)
+# =============================================================================
+JWT_SECRET=replace-me-with-a-long-random-secret
+JWT_EXPIRES_IN=15m
+REFRESH_SECRET=replace-me-with-a-different-long-random-secret
+REFRESH_EXPIRES_IN=7d
+SALT_ROUNDS=10
+
+# =============================================================================
+# Database — Neon (Postgres serverless)
+# =============================================================================
+DATABASE_URL=postgresql://user:password@host/dbname?sslmode=require
+DATABASE_URL_UNPOOLED=postgresql://user:password@host-direct/dbname?sslmode=require
+
+# =============================================================================
+# Redis
+# =============================================================================
+REDIS_URL=redis://localhost:6379
+
+# =============================================================================
+# Email (Resend)
+# =============================================================================
+RESEND_API_KEY=re_your_api_key_here
+RESEND_FROM=HackChain <no-reply@hackchain.app>
+
+# =============================================================================
+# Frontend integration
+# =============================================================================
+FRONTEND_URL=https://www.hackchain.app
+
+# =============================================================================
+# CAPTCHA (Cloudflare Turnstile — optional)
+# =============================================================================
+# TURNSTILE_SECRET=
+
+# =============================================================================
+# IPFS (Pinata)
+# =============================================================================
+PINATA_JWT=your_pinata_jwt
+GATEWAY_URL=https://gateway.pinata.cloud
+
+# =============================================================================
+# On-chain (Polygon)
+# =============================================================================
+POLYGON_RPC_URL=https://polygon-rpc.com
+RPC_URL=https://polygon-rpc.com
+POLYGON_OWNER_PRIVATE_KEY=0x
+SENDER_PRIVATE_KEY=0x
+ADMIN_WALLET=0x
+
+# =============================================================================
+# OpenSea
+# =============================================================================
+OPENSEA_API_KEY=
+
+# =============================================================================
+# Harjoot integration (this module)
+# =============================================================================
+HARJOOT_API_BASE_URL=https://harjoot.com/api/partner/hackchain/v1
+HARJOOT_PARTNER_API_KEY=
+HARJOOT_TIMEOUT_MS=10000
+HARJOOT_MAX_RETRIES=2
+HARJOOT_RETRY_BASE_DELAY_MS=300
+HARJOOT_USE_MOCK=false
+
+# =============================================================================
+# Pricing (DS decision 8 — RESOLVED 2026-05-22)
+# =============================================================================
+HARJOOT_PRICE_USD_CENTS=20
+USER_PRICE_USD_CENTS=69
+HACK_PRICE_USD_MICROS=100

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 .env
 .env.backup
+.env.example
 
 # Editor directories and files
 .vscode/*

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -13,7 +13,6 @@ dist-ssr
 *.local
 .env
 .env.backup
-.env.example
 
 # Editor directories and files
 .vscode/*

--- a/backend/harjoot/README.md
+++ b/backend/harjoot/README.md
@@ -1,0 +1,99 @@
+# `harjoot/` — Integración con Harjoot Partner API
+
+Módulo aislado para toda la comunicación con Harjoot (proveedor de
+verificación de certificados). Si mañana se cambia de proveedor, todo lo
+relevante vive acá.
+
+## Estructura
+
+```
+harjoot/
+├── config.js              Carga + valida env vars al module load (throw rápido si falta algo crítico)
+├── client/
+│   ├── errors.js          Jerarquía HarjootError + map de axios error → tipado
+│   ├── httpClient.js      Cliente real con axios + interceptors + retry inline
+│   ├── mockClient.js      Stub in-process con respuestas alineadas al PDF
+│   ├── factory.js         createHarjootClient(config) — elige http vs mock por env
+│   ├── index.js           Barrel público (importar siempre desde acá)
+│   └── __tests__/         Unit tests con axios mockeado
+└── README.md              (este archivo)
+```
+
+## Uso desde el resto del backend
+
+```js
+const { createHarjootClient } = require("./harjoot/client");
+const harjoot = createHarjootClient();
+
+await harjoot.getPartnerInfo();
+await harjoot.activateAccess("issuer", userRow, { organization_name: "Acme U" });
+await harjoot.checkAccess(walletAddress, "student");
+await harjoot.uploadCertificate({ /* ver docs/client-integration-guide.pdf */ });
+```
+
+## Cliente real vs mock
+
+Controlado por la env var `HARJOOT_USE_MOCK`:
+
+| Valor | Resultado |
+|-------|-----------|
+| `false` (o sin setear) | `createHarjootClient()` devuelve el cliente HTTP real que pega a `HARJOOT_API_BASE_URL`. |
+| `true` | Devuelve un mock in-process con respuestas hardcodeadas alineadas al PDF. Útil para correr el backend sin credenciales y para tests E2E rápidos. |
+
+## Manejo de errores
+
+Cada error del cliente HTTP se mapea a una subclase de `HarjootError`:
+
+| Subclase | Cuándo | `status` que retorna HackChain |
+|----------|--------|--------------------------------|
+| `HarjootAuthError` | Harjoot rechazó la API key (401/403) | 500 (es problema de config nuestro) |
+| `HarjootRateLimitError` | 429 de Harjoot | 503 |
+| `HarjootValidationError` | 400 / 422 de Harjoot | 502 |
+| `HarjootNotFoundError` | 404 de Harjoot | 502 (los routes pueden re-throw como 404) |
+| `HarjootServerError` | 5xx de Harjoot (tras retries) | 502 |
+| `HarjootUnavailableError` | Error de red / timeout | 503 |
+
+El global error handler de `backend/index.js:143-147` **respeta `err.status`**
+automáticamente — los routes no necesitan mapear códigos.
+
+## Retry
+
+El interceptor de response reintenta hasta `HARJOOT_MAX_RETRIES` veces sobre:
+- Errores de red (no `response`).
+- 5xx de Harjoot.
+
+Backoff lineal: `HARJOOT_RETRY_BASE_DELAY_MS * attempt`. Los 4xx **NO** se
+reintentan (son determinísticos).
+
+## Logging
+
+Convención del proyecto: `console.*` con prefijo `[harjoot]`. El interceptor
+de request sanitiza headers — **nunca** se loggea `x-api-key` ni
+`Authorization`.
+
+## Tests
+
+```bash
+# Todos los tests del módulo
+npx jest --testPathPatterns='harjoot'
+
+# Solo httpClient
+npx jest --testPathPatterns='harjoot/client/__tests__/httpClient'
+```
+
+Los tests mockean `axios` con `jest.mock("axios")`. No tocan red.
+
+## Referencias
+
+- `documents/client-integration-guide.pdf` — contrato oficial de Harjoot.
+- `documents/hackchain-harjoot-integration-gaps.pdf` — namespace HackChain.
+- `documents/hackchain-harjoot-sequence.txt` — DS v5 con los flujos completos.
+- `documents/harjoot-implementation-plan.md` — plan general de implementación.
+- `documents/harjoot-integration-handoff.md` — handoff del scaffold inicial.
+
+## Mapping de roles
+
+HackChain usa internamente `student / issuer / recruiter`. Harjoot espera el
+segmento `talent / educator / recruiter`. El mapping vive en
+`client/httpClient.js` como `ROLE_TO_SEGMENT` y se aplica automáticamente
+dentro del cliente — los callers pasan el rol HackChain.

--- a/backend/harjoot/client/__tests__/factory.test.js
+++ b/backend/harjoot/client/__tests__/factory.test.js
@@ -1,0 +1,71 @@
+// backend/harjoot/client/__tests__/factory.test.js
+//
+// Verifies the factory picks the right client based on useMock and that
+// callers always receive an object exposing the canonical 5-method surface.
+
+jest.mock("axios");
+const axios = require("axios");
+
+// Suppress client logs during construction.
+beforeAll(() => {
+  jest.spyOn(console, "log").mockImplementation(() => {});
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+const { createHarjootClient } = require("../factory");
+
+const baseConfig = Object.freeze({
+  api: Object.freeze({
+    baseUrl: "https://harjoot.test/api/partner/hackchain/v1",
+    apiKey: "test-key",
+    timeoutMs: 1000,
+    maxRetries: 1,
+    retryBaseDelayMs: 1,
+  }),
+});
+
+describe("factory.createHarjootClient", () => {
+  beforeEach(() => {
+    axios.create.mockReturnValue({
+      interceptors: { request: { use: jest.fn() }, response: { use: jest.fn() } },
+    });
+  });
+
+  test("returns the mock client when useMock=true", () => {
+    const client = createHarjootClient({ ...baseConfig, useMock: true });
+    expect(client.__calls).toBeDefined();
+    expect(typeof client.__setNextResponse).toBe("function");
+    expect(typeof client.__setNextError).toBe("function");
+    expect(typeof client.__reset).toBe("function");
+  });
+
+  test("returns the HTTP client when useMock=false", () => {
+    const client = createHarjootClient({ ...baseConfig, useMock: false });
+    expect(client.__calls).toBeUndefined();
+    expect(client.__setNextResponse).toBeUndefined();
+    expect(axios.create).toHaveBeenCalledWith({
+      baseURL: baseConfig.api.baseUrl,
+      timeout: baseConfig.api.timeoutMs,
+      headers: { "x-api-key": baseConfig.api.apiKey },
+    });
+  });
+
+  test("treats absent useMock as false (HTTP client)", () => {
+    const client = createHarjootClient(baseConfig);
+    expect(client.__calls).toBeUndefined();
+  });
+
+  test.each(["getPartnerInfo", "activateAccess", "checkAccess", "uploadCertificate", "notifyPayment"])(
+    "both clients expose method %s",
+    (methodName) => {
+      const http = createHarjootClient({ ...baseConfig, useMock: false });
+      const mock = createHarjootClient({ ...baseConfig, useMock: true });
+      expect(typeof http[methodName]).toBe("function");
+      expect(typeof mock[methodName]).toBe("function");
+    },
+  );
+});

--- a/backend/harjoot/client/__tests__/httpClient.test.js
+++ b/backend/harjoot/client/__tests__/httpClient.test.js
@@ -1,0 +1,398 @@
+// backend/harjoot/client/__tests__/httpClient.test.js
+//
+// Unit tests for the real Harjoot HTTP client.
+// Axios is mocked so the tests verify request shape, error mapping, and retry
+// behaviour without hitting any network.
+
+jest.mock("axios");
+const axios = require("axios");
+
+// Silence the client's console output during tests. Individual tests that
+// want to assert log content can re-enable a single channel via jest.spyOn.
+beforeAll(() => {
+  jest.spyOn(console, "log").mockImplementation(() => {});
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+const { createHttpClient, ROLE_TO_SEGMENT } = require("../httpClient");
+const {
+  HarjootAuthError,
+  HarjootRateLimitError,
+  HarjootValidationError,
+  HarjootNotFoundError,
+  HarjootServerError,
+  HarjootUnavailableError,
+  HarjootError,
+} = require("../errors");
+
+const testConfig = Object.freeze({
+  api: Object.freeze({
+    baseUrl: "https://harjoot.test/api/partner/hackchain/v1",
+    apiKey: "test-key-xyz",
+    timeoutMs: 1000,
+    maxRetries: 2,
+    retryBaseDelayMs: 1, // keep tests fast
+  }),
+});
+
+// Build a fake axios instance whose interceptors run the same way as the
+// real one. We expose a request shim per test so we can control responses.
+function buildFakeAxiosInstance() {
+  const instance = {
+    interceptors: {
+      request: { handlers: [], use(fn) { this.handlers.push(fn); } },
+      response: { handlers: [], use(ok, err) { this.handlers.push({ ok, err }); } },
+    },
+    // The actual implementation injected per test:
+    _impl: null,
+  };
+
+  async function callable(config) {
+    // Run request interceptors
+    let cfg = config;
+    for (const handler of instance.interceptors.request.handlers) {
+      cfg = handler(cfg);
+    }
+    // Run the impl
+    let result;
+    try {
+      result = await instance._impl(cfg);
+    } catch (err) {
+      // Run response error interceptors
+      for (const { err: errHandler } of instance.interceptors.response.handlers) {
+        if (errHandler) {
+          try {
+            return await errHandler(err);
+          } catch (mapped) {
+            err = mapped;
+          }
+        }
+      }
+      throw err;
+    }
+    // Run response success interceptors
+    for (const { ok } of instance.interceptors.response.handlers) {
+      if (ok) result = ok(result);
+    }
+    return result;
+  }
+
+  // Method helpers
+  callable.get = (url, opts = {}) => callable({ method: "get", url, ...opts, headers: instance._headers });
+  callable.post = (url, data, opts = {}) => callable({ method: "post", url, data, ...opts, headers: instance._headers });
+
+  // Attach interceptors property
+  callable.interceptors = instance.interceptors;
+  callable._setImpl = (fn) => { instance._impl = fn; };
+  callable._setHeaders = (h) => { instance._headers = h; };
+
+  return callable;
+}
+
+describe("httpClient — createHttpClient", () => {
+  let fakeAxios;
+
+  beforeEach(() => {
+    fakeAxios = buildFakeAxiosInstance();
+    axios.create.mockImplementation((createOpts) => {
+      fakeAxios._setHeaders(createOpts.headers);
+      return fakeAxios;
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // axios.create configuration
+  // -------------------------------------------------------------------------
+
+  test("creates axios with baseURL, timeout, and x-api-key header", () => {
+    createHttpClient(testConfig);
+    expect(axios.create).toHaveBeenCalledWith({
+      baseURL: testConfig.api.baseUrl,
+      timeout: testConfig.api.timeoutMs,
+      headers: { "x-api-key": testConfig.api.apiKey },
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getPartnerInfo — Section 0
+  // -------------------------------------------------------------------------
+
+  test("getPartnerInfo calls GET /partners/me and returns response data", async () => {
+    const payload = { partner: { slug: "hackchain", active: true }, modes: ["hash_only"] };
+    fakeAxios._setImpl(async (cfg) => {
+      expect(cfg.method).toBe("get");
+      expect(cfg.url).toBe("/partners/me");
+      return { status: 200, data: payload, config: cfg };
+    });
+
+    const client = createHttpClient(testConfig);
+    const result = await client.getPartnerInfo();
+    expect(result).toEqual(payload);
+  });
+
+  // -------------------------------------------------------------------------
+  // activateAccess — Section 2 — role to segment mapping + body shape
+  // -------------------------------------------------------------------------
+
+  test("activateAccess maps issuer role to educator segment and includes issuer profile", async () => {
+    const user = { id: 42, wallet_address: "0xabc", role: "issuer", name: "Edu", lastname: "Cator", email: "e@x.com" };
+    const profile = { organization_name: "Cyber Academy" };
+
+    let receivedBody;
+    fakeAxios._setImpl(async (cfg) => {
+      expect(cfg.method).toBe("post");
+      expect(cfg.url).toBe("/access/activate");
+      receivedBody = cfg.data;
+      return { status: 200, data: { success: true }, config: cfg };
+    });
+
+    const client = createHttpClient(testConfig);
+    await client.activateAccess("issuer", user, profile);
+
+    expect(receivedBody.segment).toBe("educator");
+    expect(receivedBody.external_user_id).toBe("42");
+    expect(receivedBody.user).toEqual({
+      id: 42,
+      wallet_address: "0xabc",
+      role: "issuer",
+      name: "Edu",
+      lastname: "Cator",
+      email: "e@x.com",
+    });
+    expect(receivedBody.issuer).toEqual({ organization_name: "Cyber Academy" });
+    expect(receivedBody.student).toBeUndefined();
+    expect(receivedBody.recruiter).toBeUndefined();
+  });
+
+  test.each([
+    ["student", "talent", "student"],
+    ["issuer", "educator", "issuer"],
+    ["recruiter", "recruiter", "recruiter"],
+  ])("activateAccess(%s) sends segment=%s and includes the %s profile key", async (role, segment, profileKey) => {
+    fakeAxios._setImpl(async (cfg) => ({ status: 200, data: {}, config: cfg }));
+    const client = createHttpClient(testConfig);
+    let body;
+    fakeAxios._setImpl(async (cfg) => { body = cfg.data; return { status: 200, data: {}, config: cfg }; });
+
+    await client.activateAccess(role, { id: 1, wallet_address: "0x", role }, { foo: "bar" });
+    expect(body.segment).toBe(segment);
+    expect(body[profileKey]).toEqual({ foo: "bar" });
+  });
+
+  test("activateAccess strips sensitive fields from user payload", async () => {
+    const user = {
+      id: 7,
+      wallet_address: "0x",
+      role: "student",
+      name: "S",
+      lastname: "T",
+      email: "s@t.com",
+      passwordHash: "DO_NOT_LEAK",
+      privateKey: "DO_NOT_LEAK_EITHER",
+    };
+
+    let body;
+    fakeAxios._setImpl(async (cfg) => { body = cfg.data; return { status: 200, data: {}, config: cfg }; });
+
+    const client = createHttpClient(testConfig);
+    await client.activateAccess("student", user, {});
+    expect(body.user.passwordHash).toBeUndefined();
+    expect(body.user.privateKey).toBeUndefined();
+  });
+
+  test("activateAccess throws TypeError on unknown role (before any HTTP)", async () => {
+    fakeAxios._setImpl(async () => { throw new Error("HTTP must not be called"); });
+    const client = createHttpClient(testConfig);
+    await expect(
+      client.activateAccess("admin", { id: 1, wallet_address: "0x" }, {}),
+    ).rejects.toThrow(TypeError);
+  });
+
+  // -------------------------------------------------------------------------
+  // checkAccess — Section 3
+  // -------------------------------------------------------------------------
+
+  test("checkAccess sends wallet_address and segment as query params", async () => {
+    let receivedConfig;
+    fakeAxios._setImpl(async (cfg) => {
+      receivedConfig = cfg;
+      return { status: 200, data: { active: true, expires_at: "2026-12-31" }, config: cfg };
+    });
+
+    const client = createHttpClient(testConfig);
+    const result = await client.checkAccess("0xWALLET", "student");
+
+    expect(receivedConfig.method).toBe("get");
+    expect(receivedConfig.url).toBe("/access/status");
+    expect(receivedConfig.params).toEqual({ wallet_address: "0xWALLET", segment: "talent" });
+    expect(result).toEqual({ active: true, expires_at: "2026-12-31" });
+  });
+
+  // -------------------------------------------------------------------------
+  // uploadCertificate — Section 4
+  // -------------------------------------------------------------------------
+
+  test("uploadCertificate POSTs the payload as-is and returns response data", async () => {
+    const payload = {
+      idempotency_key: "cert-uuid-v1",
+      processing: { mode: "hash_only" },
+      issuer: { wallet_address: "0xi" },
+      student: { wallet_address: "0xs" },
+      certificate: { id: "CERT-1", title: "T", certificate_hash: "a".repeat(64), issue_date: "2026-01-01" },
+      document: { filename: "c.pdf", content_type: "application/pdf", hash: "a".repeat(64) },
+    };
+    const upstreamData = { success: true, certificate: { verificationId: "HJ-P-2026-X" } };
+
+    let received;
+    fakeAxios._setImpl(async (cfg) => {
+      received = cfg;
+      return { status: 200, data: upstreamData, config: cfg };
+    });
+
+    const client = createHttpClient(testConfig);
+    const result = await client.uploadCertificate(payload);
+
+    expect(received.method).toBe("post");
+    expect(received.url).toBe("/certificates/upload");
+    expect(received.data).toBe(payload);
+    expect(result).toEqual(upstreamData);
+  });
+
+  // -------------------------------------------------------------------------
+  // notifyPayment — Section 13 (stub)
+  // -------------------------------------------------------------------------
+
+  test("notifyPayment throws a typed not-configured error (TODO 6)", async () => {
+    const client = createHttpClient(testConfig);
+    await expect(client.notifyPayment(["HJ-1"], "0xTX")).rejects.toMatchObject({
+      name: "HarjootError",
+      code: "HARJOOT_PAYMENT_NOTIFY_NOT_CONFIGURED",
+      status: 501,
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Error mapping (response interceptor)
+  // -------------------------------------------------------------------------
+
+  test.each([
+    [401, HarjootAuthError],
+    [403, HarjootAuthError],
+    [404, HarjootNotFoundError],
+    [422, HarjootValidationError],
+    [400, HarjootValidationError],
+    [429, HarjootRateLimitError],
+  ])("maps upstream %i to %p", async (status, ErrorClass) => {
+    fakeAxios._setImpl(async () => {
+      const err = new Error("upstream");
+      err.response = { status, data: { error: "upstream" } };
+      err.config = { method: "get", url: "/partners/me", _retryCount: 0 };
+      throw err;
+    });
+
+    const client = createHttpClient(testConfig);
+    await expect(client.getPartnerInfo()).rejects.toBeInstanceOf(ErrorClass);
+  });
+
+  test("maps network errors (no response) to HarjootUnavailableError", async () => {
+    fakeAxios._setImpl(async () => {
+      const err = new Error("ECONNRESET");
+      err.code = "ECONNRESET";
+      err.config = { method: "get", url: "/partners/me", _retryCount: 999 }; // skip retries
+      throw err;
+    });
+
+    const client = createHttpClient(testConfig);
+    await expect(client.getPartnerInfo()).rejects.toBeInstanceOf(HarjootUnavailableError);
+  });
+
+  // -------------------------------------------------------------------------
+  // Retry behaviour
+  // -------------------------------------------------------------------------
+
+  test("retries on 5xx up to maxRetries then maps to HarjootServerError", async () => {
+    let attempts = 0;
+    fakeAxios._setImpl(async (cfg) => {
+      attempts += 1;
+      const err = new Error("upstream 500");
+      err.response = { status: 500, data: { error: "boom" } };
+      err.config = cfg;
+      throw err;
+    });
+
+    const client = createHttpClient(testConfig);
+    await expect(client.getPartnerInfo()).rejects.toBeInstanceOf(HarjootServerError);
+    // First attempt + maxRetries retries = 1 + 2 = 3
+    expect(attempts).toBe(testConfig.api.maxRetries + 1);
+  });
+
+  test("retries on network error then maps to HarjootUnavailableError when exhausted", async () => {
+    let attempts = 0;
+    fakeAxios._setImpl(async (cfg) => {
+      attempts += 1;
+      const err = new Error("ETIMEDOUT");
+      err.code = "ETIMEDOUT";
+      // No err.response — network error.
+      err.config = cfg;
+      throw err;
+    });
+
+    const client = createHttpClient(testConfig);
+    await expect(client.getPartnerInfo()).rejects.toBeInstanceOf(HarjootUnavailableError);
+    expect(attempts).toBe(testConfig.api.maxRetries + 1);
+  });
+
+  test("does NOT retry on 4xx (client errors are deterministic)", async () => {
+    let attempts = 0;
+    fakeAxios._setImpl(async (cfg) => {
+      attempts += 1;
+      const err = new Error("bad request");
+      err.response = { status: 422, data: { error: "validation" } };
+      err.config = cfg;
+      throw err;
+    });
+
+    const client = createHttpClient(testConfig);
+    await expect(client.getPartnerInfo()).rejects.toBeInstanceOf(HarjootValidationError);
+    expect(attempts).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Header sanitization
+  // -------------------------------------------------------------------------
+
+  test("request interceptor does NOT log the x-api-key", async () => {
+    const logSpy = jest.spyOn(console, "log");
+    logSpy.mockClear();
+
+    fakeAxios._setImpl(async (cfg) => ({ status: 200, data: {}, config: cfg }));
+    const client = createHttpClient(testConfig);
+    await client.getPartnerInfo();
+
+    const allLoggedArgs = logSpy.mock.calls.flat();
+    const allLoggedJson = JSON.stringify(allLoggedArgs);
+    expect(allLoggedJson).not.toContain(testConfig.api.apiKey);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// ROLE_TO_SEGMENT constant
+// -----------------------------------------------------------------------------
+
+describe("ROLE_TO_SEGMENT", () => {
+  test("maps the three HackChain roles to Harjoot segments", () => {
+    expect(ROLE_TO_SEGMENT.student).toBe("talent");
+    expect(ROLE_TO_SEGMENT.issuer).toBe("educator");
+    expect(ROLE_TO_SEGMENT.recruiter).toBe("recruiter");
+  });
+
+  test("is frozen — mutations are silently rejected and the value is preserved", () => {
+    ROLE_TO_SEGMENT.student = "hacked";
+    expect(ROLE_TO_SEGMENT.student).toBe("talent");
+    expect(Object.isFrozen(ROLE_TO_SEGMENT)).toBe(true);
+  });
+});

--- a/backend/harjoot/client/__tests__/mockClient.test.js
+++ b/backend/harjoot/client/__tests__/mockClient.test.js
@@ -1,0 +1,149 @@
+// backend/harjoot/client/__tests__/mockClient.test.js
+//
+// Verifies the mock client behaves as a drop-in substitute for the real one:
+// well-formed default responses, call tracking, and override helpers.
+
+const { createMockClient } = require("../mockClient");
+const { HarjootError } = require("../errors");
+
+describe("mockClient — default responses", () => {
+  let client;
+  beforeEach(() => {
+    client = createMockClient();
+  });
+
+  test("getPartnerInfo returns a partner object with hackchain slug and modes", async () => {
+    const result = await client.getPartnerInfo();
+    expect(result.partner).toMatchObject({ slug: "hackchain", active: true });
+    expect(result.modes).toEqual(expect.arrayContaining(["hash_only"]));
+  });
+
+  test.each([
+    ["student", "talent"],
+    ["issuer", "educator"],
+    ["recruiter", "recruiter"],
+  ])("activateAccess(%s) returns an active membership with segment %s", async (role, segment) => {
+    const result = await client.activateAccess(role, { id: 1, wallet_address: "0x" }, {});
+    expect(result.success).toBe(true);
+    expect(result.membership.active).toBe(true);
+    expect(result.membership.segment).toBe(segment);
+    expect(new Date(result.membership.expires_at).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  test("checkAccess returns active + expires_at in the future", async () => {
+    const result = await client.checkAccess("0xWALLET", "student");
+    expect(result.active).toBe(true);
+    expect(new Date(result.expires_at).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  test("uploadCertificate echoes the document hash and produces verification URLs", async () => {
+    const payload = {
+      certificate: { id: "CERT-7", certificate_hash: "a".repeat(64) },
+      document: { hash: "b".repeat(64) },
+    };
+    const result = await client.uploadCertificate(payload);
+
+    expect(result.success).toBe(true);
+    expect(result.certificate.partnerCertificateId).toBe("CERT-7");
+    expect(result.certificate.document.hash).toBe("b".repeat(64));
+    expect(result.certificate.verificationId).toMatch(/^HJ-P-MOCK-/);
+    expect(result.certificate.verification.url).toContain(result.certificate.verificationId);
+    expect(result.certificate.verification.qrCodeUrl).toContain(result.certificate.verificationId);
+  });
+
+  test("uploadCertificate falls back to certificate_hash when document.hash is absent", async () => {
+    const payload = { certificate: { id: "X", certificate_hash: "c".repeat(64) } };
+    const result = await client.uploadCertificate(payload);
+    expect(result.certificate.document.hash).toBe("c".repeat(64));
+  });
+
+  test("notifyPayment resolves with success (unlike the real client which throws)", async () => {
+    const result = await client.notifyPayment(["HJ-1"], "0xTX");
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("mockClient — call tracking", () => {
+  test("records every invocation with method name and args", async () => {
+    const client = createMockClient();
+    await client.getPartnerInfo();
+    await client.checkAccess("0x", "student");
+    await client.activateAccess("issuer", { id: 1, wallet_address: "0x" }, { organization_name: "Acme U" });
+
+    expect(client.__calls).toHaveLength(3);
+    expect(client.__calls[0]).toEqual({ method: "getPartnerInfo", args: [] });
+    expect(client.__calls[1]).toEqual({ method: "checkAccess", args: ["0x", "student"] });
+    expect(client.__calls[2].method).toBe("activateAccess");
+    expect(client.__calls[2].args[0]).toBe("issuer");
+  });
+
+  test("__reset clears calls and pending overrides", async () => {
+    const client = createMockClient();
+    await client.getPartnerInfo();
+    client.__setNextResponse("checkAccess", { active: false });
+    client.__setNextError("uploadCertificate", new HarjootError("boom"));
+
+    client.__reset();
+
+    expect(client.__calls).toHaveLength(0);
+    // After reset, defaults apply again — no error and no override.
+    const accessResult = await client.checkAccess("0x", "student");
+    expect(accessResult.active).toBe(true);
+  });
+});
+
+describe("mockClient — override helpers", () => {
+  let client;
+  beforeEach(() => {
+    client = createMockClient();
+  });
+
+  test("__setNextResponse overrides the very next call (one-shot)", async () => {
+    client.__setNextResponse("getPartnerInfo", { partner: { slug: "override", active: false } });
+
+    const first = await client.getPartnerInfo();
+    expect(first.partner.slug).toBe("override");
+    expect(first.partner.active).toBe(false);
+
+    // Second call falls back to default.
+    const second = await client.getPartnerInfo();
+    expect(second.partner.slug).toBe("hackchain");
+  });
+
+  test("__setNextError makes the next call reject (one-shot)", async () => {
+    const boom = new HarjootError("upstream went down");
+    client.__setNextError("checkAccess", boom);
+
+    await expect(client.checkAccess("0x", "student")).rejects.toBe(boom);
+    // Subsequent calls succeed with default response.
+    await expect(client.checkAccess("0x", "student")).resolves.toMatchObject({ active: true });
+  });
+
+  test("__setNextResponse with unknown method throws TypeError", () => {
+    expect(() => client.__setNextResponse("notAMethod", {})).toThrow(TypeError);
+  });
+
+  test("__setNextError with unknown method throws TypeError", () => {
+    expect(() => client.__setNextError("notAMethod", new Error())).toThrow(TypeError);
+  });
+
+  test("error takes precedence over response when both are queued for the same method", async () => {
+    client.__setNextResponse("getPartnerInfo", { partner: { slug: "x" } });
+    client.__setNextError("getPartnerInfo", new HarjootError("force"));
+
+    await expect(client.getPartnerInfo()).rejects.toThrow("force");
+    // The next call still has the response queued — error was the one consumed.
+    await expect(client.getPartnerInfo()).resolves.toMatchObject({ partner: { slug: "x" } });
+  });
+});
+
+describe("mockClient — public surface matches httpClient", () => {
+  test("exposes the same five methods as the real client", () => {
+    const client = createMockClient();
+    expect(typeof client.getPartnerInfo).toBe("function");
+    expect(typeof client.activateAccess).toBe("function");
+    expect(typeof client.checkAccess).toBe("function");
+    expect(typeof client.uploadCertificate).toBe("function");
+    expect(typeof client.notifyPayment).toBe("function");
+  });
+});

--- a/backend/harjoot/client/errors.js
+++ b/backend/harjoot/client/errors.js
@@ -1,0 +1,133 @@
+// backend/harjoot/client/errors.js
+//
+// Typed error hierarchy for the Harjoot client.
+//
+// Each error carries a `status` property that the global error handler in
+// backend/index.js maps directly to the HTTP response status — routes do not
+// have to translate codes manually.
+//
+// The `status` reflects what HackChain returns to ITS clients, NOT what
+// Harjoot returned to us. For example, Harjoot rejecting our API key (401)
+// becomes a 500 here because it is a configuration problem on our side, not
+// an auth problem of the end user.
+
+class HarjootError extends Error {
+  /**
+   * @param {string} message
+   * @param {object} [options]
+   * @param {number} [options.status=502]      HTTP status to return to our clients.
+   * @param {string} [options.code]            Stable error code (e.g. HARJOOT_AUTH).
+   * @param {number} [options.upstreamStatus]  HTTP status received from Harjoot, if any.
+   * @param {unknown} [options.upstreamBody]   Response body from Harjoot, if any.
+   * @param {Error}  [options.cause]           Original error (network, axios).
+   */
+  constructor(message, { status = 502, code = "HARJOOT_ERROR", upstreamStatus, upstreamBody, cause } = {}) {
+    super(message);
+    this.name = "HarjootError";
+    this.status = status;
+    this.code = code;
+    this.upstreamStatus = upstreamStatus;
+    this.upstreamBody = upstreamBody;
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+// Harjoot rejected our API key. This is OUR config problem, not the end user's.
+class HarjootAuthError extends HarjootError {
+  constructor(opts = {}) {
+    super("Harjoot API key was rejected", { status: 500, code: "HARJOOT_AUTH", ...opts });
+    this.name = "HarjootAuthError";
+  }
+}
+
+// Harjoot rate-limited us. Treat as temporary upstream unavailability.
+class HarjootRateLimitError extends HarjootError {
+  constructor(opts = {}) {
+    super("Harjoot rate limit exceeded", { status: 503, code: "HARJOOT_RATE_LIMITED", ...opts });
+    this.name = "HarjootRateLimitError";
+  }
+}
+
+// We sent a payload Harjoot considers invalid. For end users this is an
+// upstream issue (we generated the request); routes can override with 400 if
+// the user provided bad input that propagated.
+class HarjootValidationError extends HarjootError {
+  constructor(message = "Harjoot rejected the request payload", opts = {}) {
+    super(message, { status: 502, code: "HARJOOT_VALIDATION", ...opts });
+    this.name = "HarjootValidationError";
+  }
+}
+
+// Harjoot says the resource does not exist. Routes typically re-throw or
+// translate this to a 404 in their own response.
+class HarjootNotFoundError extends HarjootError {
+  constructor(message = "Resource not found in Harjoot", opts = {}) {
+    super(message, { status: 502, code: "HARJOOT_NOT_FOUND", ...opts });
+    this.name = "HarjootNotFoundError";
+  }
+}
+
+// Harjoot returned a 5xx. Retried in the http client; surfaces here only when
+// retries are exhausted.
+class HarjootServerError extends HarjootError {
+  constructor(opts = {}) {
+    super("Harjoot server error", { status: 502, code: "HARJOOT_SERVER_ERROR", ...opts });
+    this.name = "HarjootServerError";
+  }
+}
+
+// Network error, DNS failure, timeout. No HTTP response received.
+class HarjootUnavailableError extends HarjootError {
+  constructor(opts = {}) {
+    super("Harjoot is unreachable", { status: 503, code: "HARJOOT_UNAVAILABLE", ...opts });
+    this.name = "HarjootUnavailableError";
+  }
+}
+
+/**
+ * Map an axios error to the appropriate typed HarjootError subclass.
+ * Used by the http client response interceptor.
+ *
+ * @param {import("axios").AxiosError} axiosError
+ * @returns {HarjootError}
+ */
+function mapAxiosErrorToHarjootError(axiosError) {
+  // No HTTP response at all — network or timeout.
+  if (!axiosError.response) {
+    return new HarjootUnavailableError({ cause: axiosError });
+  }
+
+  const upstreamStatus = axiosError.response.status;
+  const upstreamBody = axiosError.response.data;
+  const opts = { upstreamStatus, upstreamBody, cause: axiosError };
+
+  if (upstreamStatus === 401 || upstreamStatus === 403) {
+    return new HarjootAuthError(opts);
+  }
+  if (upstreamStatus === 404) {
+    return new HarjootNotFoundError(undefined, opts);
+  }
+  if (upstreamStatus === 429) {
+    return new HarjootRateLimitError(opts);
+  }
+  if (upstreamStatus === 400 || upstreamStatus === 422) {
+    return new HarjootValidationError(undefined, opts);
+  }
+  if (upstreamStatus >= 500) {
+    return new HarjootServerError(opts);
+  }
+
+  // Anything else (304, 3xx, ...) — bubble up as base error with the upstream code.
+  return new HarjootError(`Unexpected Harjoot response (status ${upstreamStatus})`, opts);
+}
+
+module.exports = {
+  HarjootError,
+  HarjootAuthError,
+  HarjootRateLimitError,
+  HarjootValidationError,
+  HarjootNotFoundError,
+  HarjootServerError,
+  HarjootUnavailableError,
+  mapAxiosErrorToHarjootError,
+};

--- a/backend/harjoot/client/factory.js
+++ b/backend/harjoot/client/factory.js
@@ -1,0 +1,26 @@
+// backend/harjoot/client/factory.js
+//
+// Single entry point for obtaining a Harjoot client. The choice between the
+// real HTTP-backed client and the in-process mock is driven by `config.useMock`
+// (env var HARJOOT_USE_MOCK), so callers don't have to know or care which one
+// they got — only the public surface matters.
+
+const defaultConfig = require("../config");
+const { createHttpClient } = require("./httpClient");
+const { createMockClient } = require("./mockClient");
+
+/**
+ * Create a Harjoot client. When `config.useMock` is true the in-process mock
+ * is returned; otherwise the real HTTP client is created bound to `config`.
+ *
+ * @param {typeof defaultConfig} [config]
+ * @returns {ReturnType<typeof createHttpClient> | ReturnType<typeof createMockClient>}
+ */
+function createHarjootClient(config = defaultConfig) {
+  if (config && config.useMock) {
+    return createMockClient();
+  }
+  return createHttpClient(config);
+}
+
+module.exports = { createHarjootClient };

--- a/backend/harjoot/client/httpClient.js
+++ b/backend/harjoot/client/httpClient.js
@@ -1,0 +1,198 @@
+// backend/harjoot/client/httpClient.js
+//
+// Real Harjoot client — wraps axios with the auth header, request/response
+// logging (with sanitization), an inline retry on transient failures, and
+// error mapping to the typed HarjootError hierarchy.
+//
+// Public surface: createHttpClient(config) returns a frozen object exposing
+// the 5 in-scope Harjoot endpoints (see DS sections 0, 2, 3, 4, 13).
+//
+// Reference: client-integration-guide.pdf, hackchain-harjoot-integration-gaps.pdf.
+
+const axios = require("axios");
+const defaultConfig = require("../config");
+const { HarjootError, mapAxiosErrorToHarjootError } = require("./errors");
+
+const LOG_PREFIX = "[harjoot]";
+
+// HackChain stores roles as student/issuer/recruiter; Harjoot expects the
+// user-facing segment talent/educator/recruiter.
+const ROLE_TO_SEGMENT = Object.freeze({
+  student: "talent",
+  issuer: "educator",
+  recruiter: "recruiter",
+});
+
+// Headers that must never reach the log output.
+const SENSITIVE_HEADERS = new Set(["x-api-key", "authorization"]);
+
+function sanitizeHeaders(headers) {
+  if (!headers) return {};
+  const safe = {};
+  for (const key of Object.keys(headers)) {
+    if (SENSITIVE_HEADERS.has(key.toLowerCase())) continue;
+    safe[key] = headers[key];
+  }
+  return safe;
+}
+
+function toSegment(role) {
+  const segment = ROLE_TO_SEGMENT[role];
+  if (!segment) {
+    throw new TypeError(`Unknown HackChain role: ${role}`);
+  }
+  return segment;
+}
+
+// Pick only the fields Harjoot needs in /access/activate. Prevents leaking
+// passwordHash, internal flags, etc., if a caller passes the full User row.
+function pickUserPayload(user) {
+  return {
+    id: user.id,
+    wallet_address: user.wallet_address,
+    role: user.role,
+    name: user.name ?? null,
+    lastname: user.lastname ?? null,
+    email: user.email ?? null,
+  };
+}
+
+function buildAxiosInstance(config) {
+  const instance = axios.create({
+    baseURL: config.api.baseUrl,
+    timeout: config.api.timeoutMs,
+    headers: { "x-api-key": config.api.apiKey },
+  });
+
+  instance.interceptors.request.use((reqConfig) => {
+    console.log(
+      `${LOG_PREFIX} ${(reqConfig.method || "get").toUpperCase()} ${reqConfig.url}`,
+      { headers: sanitizeHeaders(reqConfig.headers) },
+    );
+    return reqConfig;
+  });
+
+  instance.interceptors.response.use(
+    (response) => {
+      console.log(`${LOG_PREFIX} ${response.status} ${response.config.url}`);
+      return response;
+    },
+    async (axiosError) => {
+      const reqConfig = axiosError.config || {};
+      reqConfig._retryCount = reqConfig._retryCount || 0;
+
+      const isNetworkError = !axiosError.response;
+      const isServerError = axiosError.response && axiosError.response.status >= 500;
+      const retryable = isNetworkError || isServerError;
+
+      if (retryable && reqConfig._retryCount < config.api.maxRetries) {
+        reqConfig._retryCount += 1;
+        const delay = config.api.retryBaseDelayMs * reqConfig._retryCount;
+        console.warn(
+          `${LOG_PREFIX} retry ${reqConfig._retryCount}/${config.api.maxRetries}` +
+            ` in ${delay}ms — ${axiosError.message}`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        return instance(reqConfig);
+      }
+
+      const mapped = mapAxiosErrorToHarjootError(axiosError);
+      console.error(`${LOG_PREFIX} ${mapped.name} — ${mapped.message}`);
+      throw mapped;
+    },
+  );
+
+  return instance;
+}
+
+/**
+ * Create a Harjoot HTTP client bound to the given configuration.
+ *
+ * @param {typeof defaultConfig} [config]
+ * @returns {{
+ *   getPartnerInfo(): Promise<object>,
+ *   activateAccess(role: string, user: object, profile: object): Promise<object>,
+ *   checkAccess(walletAddress: string, role: string): Promise<object>,
+ *   uploadCertificate(payload: object): Promise<object>,
+ *   notifyPayment(verificationIds: string[], usdtTxHash: string): Promise<object>,
+ * }}
+ */
+function createHttpClient(config = defaultConfig) {
+  const http = buildAxiosInstance(config);
+
+  return Object.freeze({
+    /**
+     * DS Section 0 — partner health check.
+     * GET /partners/me
+     */
+    async getPartnerInfo() {
+      const response = await http.get("/partners/me");
+      return response.data;
+    },
+
+    /**
+     * DS Section 2 — register the user in Harjoot and create a membership.
+     * POST /access/activate
+     *
+     * @param {"student"|"issuer"|"recruiter"} role  HackChain role.
+     * @param {object} user     Full HackChain User row (sanitized internally).
+     * @param {object} profile  Role-specific profile fields.
+     */
+    async activateAccess(role, user, profile) {
+      const segment = toSegment(role);
+      const body = {
+        segment,
+        external_user_id: String(user.id),
+        user: pickUserPayload(user),
+      };
+      if (role === "student") body.student = profile;
+      else if (role === "issuer") body.issuer = profile;
+      else body.recruiter = profile;
+
+      const response = await http.post("/access/activate", body);
+      return response.data;
+    },
+
+    /**
+     * DS Section 3 — confirm the user still has an active membership.
+     * GET /access/status?wallet_address=...&segment=...
+     */
+    async checkAccess(walletAddress, role) {
+      const segment = toSegment(role);
+      const response = await http.get("/access/status", {
+        params: { wallet_address: walletAddress, segment },
+      });
+      return response.data;
+    },
+
+    /**
+     * DS Section 4 — store the certificate proof in Harjoot.
+     * POST /certificates/upload
+     *
+     * Callers are responsible for assembling the full payload according to the
+     * spec: idempotency_key, processing.mode, issuer, student, certificate,
+     * document. See documents/client-integration-guide.pdf §4.
+     */
+    async uploadCertificate(payload) {
+      const response = await http.post("/certificates/upload", payload);
+      return response.data;
+    },
+
+    /**
+     * DS Section 13 — notify Harjoot of a settled USDT payment.
+     *
+     * The exact endpoint and payload are still TBD with Harjoot's team
+     * (DS TODO 6). This method throws a typed not-implemented error until the
+     * contract is defined; the worker logs it and marks the transfer as
+     * sent_but_not_notified for ops to reconcile.
+     */
+    async notifyPayment(_verificationIds, _usdtTxHash) {
+      throw new HarjootError(
+        "Harjoot payment notification endpoint is not yet defined (DS TODO 6)",
+        { status: 501, code: "HARJOOT_PAYMENT_NOTIFY_NOT_CONFIGURED" },
+      );
+    },
+  });
+}
+
+module.exports = { createHttpClient, ROLE_TO_SEGMENT };

--- a/backend/harjoot/client/index.js
+++ b/backend/harjoot/client/index.js
@@ -1,0 +1,17 @@
+// backend/harjoot/client/index.js
+//
+// Public barrel for the Harjoot client. Consumers should import from here
+// rather than reaching into the individual files.
+
+const { createHarjootClient } = require("./factory");
+const { createHttpClient, ROLE_TO_SEGMENT } = require("./httpClient");
+const { createMockClient } = require("./mockClient");
+const errors = require("./errors");
+
+module.exports = {
+  createHarjootClient,
+  createHttpClient,
+  createMockClient,
+  ROLE_TO_SEGMENT,
+  ...errors,
+};

--- a/backend/harjoot/client/mockClient.js
+++ b/backend/harjoot/client/mockClient.js
@@ -1,0 +1,167 @@
+// backend/harjoot/client/mockClient.js
+//
+// In-process Harjoot client stub. Two purposes:
+//
+//   1. Server mode — when HARJOOT_USE_MOCK=true, the backend can run end-to-end
+//      without the real partner API. Every method resolves with a well-formed
+//      response that matches the shape documented in client-integration-guide.pdf
+//      and hackchain-harjoot-integration-gaps.pdf.
+//
+//   2. Test mode — the returned client exposes underscore-prefixed helpers
+//      (__calls, __setNextResponse, __setNextError, __reset) that let unit
+//      tests assert what was called and force specific outcomes per call.
+//
+// This stub matches the surface of httpClient.createHttpClient() exactly so
+// the two are drop-in substitutable.
+
+const { ROLE_TO_SEGMENT } = require("./httpClient");
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+function thirtyDaysFromNow() {
+  return new Date(Date.now() + THIRTY_DAYS_MS).toISOString();
+}
+
+function mockVerificationId() {
+  // Format mirrors Harjoot's HJ-P-<year>-<id>. We add a MOCK marker so logs
+  // make clear this is not a real anchored proof.
+  const stamp = Date.now().toString(36).toUpperCase();
+  return `HJ-P-MOCK-${stamp}`;
+}
+
+const DEFAULT_RESPONSES = {
+  getPartnerInfo() {
+    return {
+      partner: { slug: "hackchain", active: true },
+      modes: ["hash_only", "anchor"],
+      fileOptions: [{ label: "PDF", contentType: "application/pdf" }],
+    };
+  },
+
+  activateAccess(role) {
+    return {
+      success: true,
+      membership: {
+        active: true,
+        expires_at: thirtyDaysFromNow(),
+        segment: ROLE_TO_SEGMENT[role] || "unknown",
+      },
+    };
+  },
+
+  checkAccess() {
+    return {
+      active: true,
+      expires_at: thirtyDaysFromNow(),
+    };
+  },
+
+  uploadCertificate(payload) {
+    const documentHash =
+      (payload && payload.document && payload.document.hash) ||
+      (payload && payload.certificate && payload.certificate.certificate_hash) ||
+      "0".repeat(64);
+    const verificationId = mockVerificationId();
+    return {
+      success: true,
+      certificate: {
+        verificationId,
+        partnerCertificateId: (payload && payload.certificate && payload.certificate.id) || "MOCK-CERT",
+        status: "verified",
+        document: { hash: documentHash },
+        verification: {
+          url: `https://harjoot.mock/verify/${verificationId}`,
+          qrCodeUrl: `https://harjoot.mock/verify/${verificationId}/qr`,
+        },
+        blockchain: { partnerTxHash: null, harjootTxHash: null, explorerUrl: null },
+      },
+    };
+  },
+
+  notifyPayment() {
+    // The real endpoint is TBD (DS TODO 6). The mock returns success so the
+    // treasury worker can be exercised end-to-end during development.
+    return {
+      success: true,
+      message: "[mock] Payment notification acknowledged",
+    };
+  },
+};
+
+/**
+ * Create a mock Harjoot client.
+ *
+ * @returns {{
+ *   getPartnerInfo(): Promise<object>,
+ *   activateAccess(role: string, user: object, profile: object): Promise<object>,
+ *   checkAccess(walletAddress: string, role: string): Promise<object>,
+ *   uploadCertificate(payload: object): Promise<object>,
+ *   notifyPayment(verificationIds: string[], usdtTxHash: string): Promise<object>,
+ *   __calls: Array<{method: string, args: unknown[]}>,
+ *   __setNextResponse(method: string, value: unknown): void,
+ *   __setNextError(method: string, error: Error): void,
+ *   __reset(): void,
+ * }}
+ */
+function createMockClient() {
+  const calls = [];
+  const nextResponses = new Map();
+  const nextErrors = new Map();
+
+  function invoke(method, args) {
+    calls.push({ method, args });
+
+    if (nextErrors.has(method)) {
+      const err = nextErrors.get(method);
+      nextErrors.delete(method);
+      return Promise.reject(err);
+    }
+    if (nextResponses.has(method)) {
+      const value = nextResponses.get(method);
+      nextResponses.delete(method);
+      return Promise.resolve(value);
+    }
+    return Promise.resolve(DEFAULT_RESPONSES[method](...args));
+  }
+
+  return {
+    // ---- Public surface (must mirror httpClient) ----
+    getPartnerInfo() {
+      return invoke("getPartnerInfo", []);
+    },
+    activateAccess(role, user, profile) {
+      return invoke("activateAccess", [role, user, profile]);
+    },
+    checkAccess(walletAddress, role) {
+      return invoke("checkAccess", [walletAddress, role]);
+    },
+    uploadCertificate(payload) {
+      return invoke("uploadCertificate", [payload]);
+    },
+    notifyPayment(verificationIds, usdtTxHash) {
+      return invoke("notifyPayment", [verificationIds, usdtTxHash]);
+    },
+
+    // ---- Test helpers (not for production use) ----
+    __calls: calls,
+    __setNextResponse(method, value) {
+      if (!(method in DEFAULT_RESPONSES)) {
+        throw new TypeError(`Unknown mock method: ${method}`);
+      }
+      nextResponses.set(method, value);
+    },
+    __setNextError(method, error) {
+      if (!(method in DEFAULT_RESPONSES)) {
+        throw new TypeError(`Unknown mock method: ${method}`);
+      }
+      nextErrors.set(method, error);
+    },
+    __reset() {
+      calls.length = 0;
+      nextResponses.clear();
+      nextErrors.clear();
+    },
+  };
+}
+
+module.exports = { createMockClient };

--- a/backend/harjoot/config.js
+++ b/backend/harjoot/config.js
@@ -1,0 +1,71 @@
+// backend/harjoot/config.js
+//
+// Centralized configuration for the Harjoot integration module.
+//
+// Reads environment variables once at module load and freezes the result.
+// Required variables throw immediately if missing — server fails to start
+// rather than failing later with an opaque error. Optional variables have
+// safe defaults defined inline.
+//
+// Pattern reference: middleware/auth.js validates JWT_SECRET / REFRESH_SECRET
+// at module load with the same approach.
+
+require("dotenv").config();
+
+// ---------------------------------------------------------------------------
+// Required variables — server must not start without these
+// ---------------------------------------------------------------------------
+
+if (!process.env.HARJOOT_API_BASE_URL) {
+  throw new Error("HARJOOT_API_BASE_URL environment variable is required");
+}
+
+if (!process.env.HARJOOT_PARTNER_API_KEY) {
+  throw new Error("HARJOOT_PARTNER_API_KEY environment variable is required");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseIntWithDefault(value, fallback, name) {
+  if (value === undefined || value === null || value === "") return fallback;
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed)) {
+    throw new Error(`${name} must be an integer (got "${value}")`);
+  }
+  return parsed;
+}
+
+function parseBool(value, fallback) {
+  if (value === undefined || value === null || value === "") return fallback;
+  return value === "true" || value === "1";
+}
+
+// ---------------------------------------------------------------------------
+// Frozen configuration object
+// ---------------------------------------------------------------------------
+
+const config = Object.freeze({
+  // Harjoot API connection
+  api: Object.freeze({
+    baseUrl:   process.env.HARJOOT_API_BASE_URL,
+    apiKey:    process.env.HARJOOT_PARTNER_API_KEY,
+    timeoutMs: parseIntWithDefault(process.env.HARJOOT_TIMEOUT_MS, 10000, "HARJOOT_TIMEOUT_MS"),
+    maxRetries: parseIntWithDefault(process.env.HARJOOT_MAX_RETRIES, 2, "HARJOOT_MAX_RETRIES"),
+    retryBaseDelayMs: parseIntWithDefault(process.env.HARJOOT_RETRY_BASE_DELAY_MS, 300, "HARJOOT_RETRY_BASE_DELAY_MS"),
+  }),
+
+  // Pricing — DS decision 8 RESOLVED 2026-05-22.
+  // Integer math only; conversions are done in paymentService.
+  pricing: Object.freeze({
+    harjootCostUsdCents:  parseIntWithDefault(process.env.HARJOOT_PRICE_USD_CENTS, 20, "HARJOOT_PRICE_USD_CENTS"),
+    userPriceUsdCents:    parseIntWithDefault(process.env.USER_PRICE_USD_CENTS, 69, "USER_PRICE_USD_CENTS"),
+    hackPriceUsdMicros:   parseIntWithDefault(process.env.HACK_PRICE_USD_MICROS, 100, "HACK_PRICE_USD_MICROS"),
+  }),
+
+  // Runtime flags
+  useMock: parseBool(process.env.HARJOOT_USE_MOCK, false),
+});
+
+module.exports = config;

--- a/backend/models/certificates.js
+++ b/backend/models/certificates.js
@@ -51,7 +51,14 @@ module.exports = (sequelize, DataTypes) => {
     is_revoked: {
       type: DataTypes.BOOLEAN,
       defaultValue: false
-    }
+    },
+
+    // ---- Phase 1 (Harjoot integration) — see scripts/migrate-harjoot-phase1.js ----
+    harjoot_verification_id:  { type: DataTypes.STRING, allowNull: true },
+    harjoot_verification_url: { type: DataTypes.STRING, allowNull: true },
+    harjoot_qr_url:           { type: DataTypes.STRING, allowNull: true },
+    payment_id:               { type: DataTypes.INTEGER, allowNull: true },
+    status:                   { type: DataTypes.STRING, allowNull: true, defaultValue: 'issued' }
   }, {
     tableName: 'certificates',
     underscored: true,
@@ -70,6 +77,14 @@ module.exports = (sequelize, DataTypes) => {
       targetKey: 'wallet_address',
       as: 'student'
     });
+
+    // Phase 1 (Harjoot integration): each issued cert may be funded by a payment.
+    if (models.Payment) {
+      Certificate.belongsTo(models.Payment, {
+        foreignKey: 'payment_id',
+        targetKey: 'id',
+      });
+    }
   };
 
   return Certificate;

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -75,6 +75,11 @@ db.Recruiter = require("./recruiters")(sequelize, DataTypes);
 db.Certificate = require("./certificates")(sequelize, DataTypes);
 db.UserSession = require("./userSessions")(sequelize, DataTypes);
 
+// Phase 1 — Harjoot integration models. See scripts/migrate-harjoot-phase1.js.
+db.Payment = require("./payments")(sequelize, DataTypes);
+db.TalentInvitation = require("./talentInvitations")(sequelize, DataTypes);
+db.TreasuryTransfer = require("./treasuryTransfers")(sequelize, DataTypes);
+
 Object.keys(db).forEach(modelName => {
   if (db[modelName].associate) {
     db[modelName].associate(db);

--- a/backend/models/payments.js
+++ b/backend/models/payments.js
@@ -1,0 +1,77 @@
+// backend/models/payments.js
+//
+// Records of $HACK payments made by educators when issuing certificates.
+// One row per on-chain transfer to the Treasury — see DS Section 4.
+//
+// `tx_hash` is unique: re-using the same transaction is rejected at the DB
+// layer (replay protection). The `*_usd` columns capture the per-cert
+// economics at the time of payment so historical revenue and Harjoot debt
+// can be reconciled even if pricing changes later.
+
+module.exports = (sequelize, DataTypes) => {
+  const Payment = sequelize.define("Payment", {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    tx_hash: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+    },
+    from_wallet: {
+      type: DataTypes.STRING(42),
+      allowNull: false,
+    },
+    // Whole HACK units. 6,900 per cert at launch pricing.
+    amount_hack: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    // What HackChain owes Harjoot per this payment.
+    harjoot_price_usd: {
+      type: DataTypes.DECIMAL(10, 4),
+      allowNull: false,
+    },
+    // What HackChain charged the educator.
+    user_price_usd: {
+      type: DataTypes.DECIMAL(10, 4),
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "confirmed",
+    },
+    purpose: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+  }, {
+    tableName: "payments",
+    underscored: true,
+    timestamps: true,
+    createdAt: "created_at",
+    updatedAt: "updated_at",
+  });
+
+  Payment.associate = (models) => {
+    // A payment can have at most one queued treasury transfer.
+    if (models.TreasuryTransfer) {
+      Payment.hasOne(models.TreasuryTransfer, {
+        foreignKey: "payment_id",
+        sourceKey: "id",
+      });
+    }
+    // A payment funds at most one certificate in the pay-per-mint model.
+    if (models.Certificate) {
+      Payment.hasOne(models.Certificate, {
+        foreignKey: "payment_id",
+        sourceKey: "id",
+      });
+    }
+  };
+
+  return Payment;
+};

--- a/backend/models/talentInvitations.js
+++ b/backend/models/talentInvitations.js
@@ -1,0 +1,65 @@
+// backend/models/talentInvitations.js
+//
+// Pending and claimed talent invitations triggered when an educator tries to
+// issue a certificate to an unregistered wallet — see DS Section 5.
+//
+// `student_wallet_address` is a string, not a foreign key, because the invited
+// wallet may not yet have a `users` row (that's the whole point of the
+// invitation). When the talent registers, the registration use case looks up
+// pending invitations by wallet and marks them claimed.
+
+module.exports = (sequelize, DataTypes) => {
+  const TalentInvitation = sequelize.define("TalentInvitation", {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    educator_user_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: "users",
+        key: "id",
+      },
+      onDelete: "CASCADE",
+    },
+    // Lowercase 0x-prefixed Ethereum address. Not an FK — the wallet may not
+    // exist as a user yet.
+    student_wallet_address: {
+      type: DataTypes.STRING(42),
+      allowNull: false,
+    },
+    email: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "pending",
+    },
+    claimed_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  }, {
+    tableName: "talent_invitations",
+    underscored: true,
+    timestamps: true,
+    createdAt: "created_at",
+    // No updatedAt: invitations transition pending -> claimed once and we
+    // capture the timestamp explicitly in `claimed_at`.
+    updatedAt: false,
+  });
+
+  TalentInvitation.associate = (models) => {
+    TalentInvitation.belongsTo(models.User, {
+      foreignKey: "educator_user_id",
+      targetKey: "id",
+      as: "educator",
+    });
+  };
+
+  return TalentInvitation;
+};

--- a/backend/models/treasuryTransfers.js
+++ b/backend/models/treasuryTransfers.js
@@ -1,0 +1,71 @@
+// backend/models/treasuryTransfers.js
+//
+// Async queue of pending HACK->USDT->Harjoot settlements drained by the
+// treasury worker — see DS Section 13.
+//
+// Each row represents the USDT debt accrued from one Payment that still needs
+// to be converted (HACK -> USDT via the chosen strategy) and transferred to
+// Harjoot's wallet. The lifecycle is:
+//   pending -> [awaiting_manual_conversion] -> sent | failed
+
+module.exports = (sequelize, DataTypes) => {
+  const TreasuryTransfer = sequelize.define("TreasuryTransfer", {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true,
+    },
+    payment_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: "payments",
+        key: "id",
+      },
+    },
+    // USDT amount we owe Harjoot for this payment. Launch value: 0.20 per cert.
+    amount_usdt_owed: {
+      type: DataTypes.DECIMAL(10, 4),
+      allowNull: false,
+    },
+    destination: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "harjoot",
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "pending",
+    },
+    usdt_tx_hash: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    error: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    sent_at: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+  }, {
+    tableName: "treasury_transfers_queue",
+    underscored: true,
+    timestamps: true,
+    createdAt: "created_at",
+    // No updatedAt: status transitions are captured by `sent_at` or by reading
+    // the row's current `status` + `error`.
+    updatedAt: false,
+  });
+
+  TreasuryTransfer.associate = (models) => {
+    TreasuryTransfer.belongsTo(models.Payment, {
+      foreignKey: "payment_id",
+      targetKey: "id",
+    });
+  };
+
+  return TreasuryTransfer;
+};

--- a/backend/models/users.js
+++ b/backend/models/users.js
@@ -21,7 +21,14 @@ module.exports = (sequelize, DataTypes) => {
     is_active: { type: DataTypes.BOOLEAN, defaultValue: true },
     email_verified: { type: DataTypes.BOOLEAN, defaultValue: false, allowNull: false },
     verification_token: { type: DataTypes.STRING(128), allowNull: true },
-    verification_token_expires_at: { type: DataTypes.DATE, allowNull: true }
+    verification_token_expires_at: { type: DataTypes.DATE, allowNull: true },
+
+    // ---- Phase 1 (Harjoot integration) — see scripts/migrate-harjoot-phase1.js ----
+    harjoot_membership_expires_at: { type: DataTypes.DATE, allowNull: true },
+    educator_approval_status:      { type: DataTypes.STRING, allowNull: true },
+    approved_at:                   { type: DataTypes.DATE, allowNull: true },
+    approved_by:                   { type: DataTypes.INTEGER, allowNull: true },
+    rejection_reason:              { type: DataTypes.TEXT, allowNull: true }
   }, {
     tableName: 'users',
     underscored: true,

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,5 +45,10 @@
   "devDependencies": {
     "jest": "^30.1.3",
     "supertest": "^7.1.4"
+  },
+  "jest": {
+    "setupFiles": [
+      "<rootDir>/tests/setup-env.js"
+    ]
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
     "start": "node --max-old-space-size=1536 index.js",
     "dev": "nodemon index.js",
     "test": "jest --runInBand --detectOpenHandles",
-    "migrate:issuer-profile": "node scripts/migrate-issuer-profile.js"
+    "migrate:issuer-profile": "node scripts/migrate-issuer-profile.js",
+    "migrate:harjoot-phase1": "node scripts/migrate-harjoot-phase1.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/migrate-harjoot-phase1.js
+++ b/backend/scripts/migrate-harjoot-phase1.js
@@ -1,0 +1,156 @@
+// backend/scripts/migrate-harjoot-phase1.js
+//
+// Phase 1 schema migration for the Harjoot integration.
+//
+// Idempotent — safe to run multiple times. Uses IF NOT EXISTS guards on every
+// CREATE/ALTER so re-runs are no-ops.
+//
+// Run with:
+//   npm run migrate:harjoot-phase1
+//
+// What this creates / alters:
+//
+//   ALTER TABLE users
+//     ADD COLUMN harjoot_membership_expires_at TIMESTAMPTZ
+//     ADD COLUMN educator_approval_status      TEXT     -- pending_approval | approved | rejected
+//     ADD COLUMN approved_at                   TIMESTAMPTZ
+//     ADD COLUMN approved_by                   INTEGER  REFERENCES users(id)
+//     ADD COLUMN rejection_reason              TEXT
+//
+//   ALTER TABLE certificates
+//     ADD COLUMN harjoot_verification_id  TEXT
+//     ADD COLUMN harjoot_verification_url TEXT
+//     ADD COLUMN harjoot_qr_url           TEXT
+//     ADD COLUMN payment_id               INTEGER  REFERENCES payments(id)
+//     ADD COLUMN status                   TEXT  DEFAULT 'issued'
+//
+//   CREATE TABLE payments (
+//     id                SERIAL PRIMARY KEY,
+//     tx_hash           TEXT UNIQUE NOT NULL,
+//     from_wallet       VARCHAR(42) NOT NULL,
+//     amount_hack       BIGINT NOT NULL,        -- bigint values fit in HACK supply
+//     harjoot_price_usd NUMERIC(10,4) NOT NULL,        -- 4 decimals = sub-cent precision
+//     user_price_usd    NUMERIC(10,4) NOT NULL,
+//     status            TEXT NOT NULL DEFAULT 'confirmed',
+//     purpose           TEXT NOT NULL,
+//     created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+//     updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+//   );
+//
+//   CREATE TABLE talent_invitations (
+//     id                     SERIAL PRIMARY KEY,
+//     educator_user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+//     student_wallet_address VARCHAR(42) NOT NULL,
+//     email                  VARCHAR(255) NOT NULL,
+//     status                 TEXT NOT NULL DEFAULT 'pending',
+//     created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+//     claimed_at             TIMESTAMPTZ
+//   );
+//
+//   CREATE TABLE treasury_transfers_queue (
+//     id                SERIAL PRIMARY KEY,
+//     payment_id        INTEGER NOT NULL REFERENCES payments(id),
+//     amount_usdt_owed  NUMERIC(10,4) NOT NULL,
+//     destination       TEXT NOT NULL DEFAULT 'harjoot',
+//     status            TEXT NOT NULL DEFAULT 'pending',
+//     usdt_tx_hash      TEXT,
+//     error             TEXT,
+//     created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+//     sent_at           TIMESTAMPTZ
+//   );
+//
+// And the indexes that matter for hot-path queries.
+
+require("dotenv").config();
+const { sequelizeAdmin } = require("../models");
+
+const STATEMENTS = [
+  // ---- users: harjoot + educator approval columns ----
+  `ALTER TABLE users ADD COLUMN IF NOT EXISTS harjoot_membership_expires_at TIMESTAMPTZ`,
+  `ALTER TABLE users ADD COLUMN IF NOT EXISTS educator_approval_status TEXT`,
+  `ALTER TABLE users ADD COLUMN IF NOT EXISTS approved_at TIMESTAMPTZ`,
+  `ALTER TABLE users ADD COLUMN IF NOT EXISTS approved_by INTEGER REFERENCES users(id)`,
+  `ALTER TABLE users ADD COLUMN IF NOT EXISTS rejection_reason TEXT`,
+
+  // ---- payments ----
+  `CREATE TABLE IF NOT EXISTS payments (
+    id                SERIAL PRIMARY KEY,
+    tx_hash           TEXT UNIQUE NOT NULL,
+    from_wallet       VARCHAR(42) NOT NULL,
+    amount_hack       BIGINT NOT NULL,
+    harjoot_price_usd NUMERIC(10,4) NOT NULL,
+    user_price_usd    NUMERIC(10,4) NOT NULL,
+    status            TEXT NOT NULL DEFAULT 'confirmed',
+    purpose           TEXT NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_payments_from_wallet ON payments (from_wallet)`,
+  `CREATE INDEX IF NOT EXISTS idx_payments_status ON payments (status)`,
+
+  // ---- talent_invitations ----
+  `CREATE TABLE IF NOT EXISTS talent_invitations (
+    id                     SERIAL PRIMARY KEY,
+    educator_user_id       INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    student_wallet_address VARCHAR(42) NOT NULL,
+    email                  VARCHAR(255) NOT NULL,
+    status                 TEXT NOT NULL DEFAULT 'pending',
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    claimed_at             TIMESTAMPTZ
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_invitations_wallet ON talent_invitations (student_wallet_address)`,
+  `CREATE INDEX IF NOT EXISTS idx_invitations_status ON talent_invitations (status)`,
+  `CREATE INDEX IF NOT EXISTS idx_invitations_educator ON talent_invitations (educator_user_id)`,
+
+  // ---- treasury_transfers_queue ----
+  `CREATE TABLE IF NOT EXISTS treasury_transfers_queue (
+    id                SERIAL PRIMARY KEY,
+    payment_id        INTEGER NOT NULL REFERENCES payments(id),
+    amount_usdt_owed  NUMERIC(10,4) NOT NULL,
+    destination       TEXT NOT NULL DEFAULT 'harjoot',
+    status            TEXT NOT NULL DEFAULT 'pending',
+    usdt_tx_hash      TEXT,
+    error             TEXT,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    sent_at           TIMESTAMPTZ
+  )`,
+  `CREATE INDEX IF NOT EXISTS idx_treasury_status ON treasury_transfers_queue (status)`,
+  `CREATE INDEX IF NOT EXISTS idx_treasury_payment ON treasury_transfers_queue (payment_id)`,
+
+  // ---- certificates: Harjoot proof + payment reference + status ----
+  // payment_id references payments, which must exist before we add the column.
+  `ALTER TABLE certificates ADD COLUMN IF NOT EXISTS harjoot_verification_id TEXT`,
+  `ALTER TABLE certificates ADD COLUMN IF NOT EXISTS harjoot_verification_url TEXT`,
+  `ALTER TABLE certificates ADD COLUMN IF NOT EXISTS harjoot_qr_url TEXT`,
+  `ALTER TABLE certificates ADD COLUMN IF NOT EXISTS payment_id INTEGER REFERENCES payments(id)`,
+  `ALTER TABLE certificates ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'issued'`,
+  `CREATE INDEX IF NOT EXISTS idx_certificates_payment ON certificates (payment_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_certificates_harjoot_verification ON certificates (harjoot_verification_id)`,
+];
+
+async function run() {
+  console.log("[migrate-harjoot-phase1] starting");
+
+  await sequelizeAdmin.authenticate();
+  console.log("[migrate-harjoot-phase1] DB connection authenticated");
+
+  for (const statement of STATEMENTS) {
+    const oneLine = statement.replace(/\s+/g, " ").trim();
+    const preview = oneLine.length > 90 ? oneLine.slice(0, 87) + "..." : oneLine;
+    console.log(`[migrate-harjoot-phase1] applying: ${preview}`);
+    await sequelizeAdmin.query(statement);
+  }
+
+  console.log(`[migrate-harjoot-phase1] done — ${STATEMENTS.length} statements applied (idempotent)`);
+}
+
+run()
+  .then(async () => {
+    await sequelizeAdmin.close();
+    process.exit(0);
+  })
+  .catch(async (err) => {
+    console.error("[migrate-harjoot-phase1] FAILED:", err);
+    try { await sequelizeAdmin.close(); } catch (_) { /* ignore */ }
+    process.exit(1);
+  });

--- a/backend/tests/harjootModels.test.js
+++ b/backend/tests/harjootModels.test.js
@@ -1,0 +1,451 @@
+// backend/tests/harjootModels.test.js
+//
+// Unit tests for the Phase 1 models (Payment, TalentInvitation, TreasuryTransfer)
+// and the new columns added to the existing User and Certificate models.
+//
+// Uses an in-memory SQLite database — same pattern as auth.test.js — so the
+// schema is materialized via sequelize.sync without touching Postgres.
+
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+
+jest.setTimeout(15000);
+
+describe("Harjoot Phase 1 models", () => {
+  let sequelize;
+  let User, Student, Issuer, Recruiter, Certificate, UserSession;
+  let Payment, TalentInvitation, TreasuryTransfer;
+
+  // Reusable test fixtures
+  const ISSUER_WALLET = "0x1111111111111111111111111111111111111111";
+  const STUDENT_WALLET = "0x2222222222222222222222222222222222222222";
+
+  beforeAll(async () => {
+    // Single-connection pool so PRAGMA foreign_keys = OFF (set below) survives
+    // across every query. The existing Student model does not mark
+    // wallet_address as unique, which SQLite (unlike Postgres) requires for any
+    // FK pointing at it — Certificate.belongsTo(Student) fails with
+    // "foreign key mismatch" otherwise. Test-only; Postgres in production
+    // enforces FKs normally.
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    await sequelize.query("PRAGMA foreign_keys = OFF");
+
+    const { DataTypes } = SequelizePkg;
+
+    User = require("../models/users")(sequelize, DataTypes);
+    Student = require("../models/students")(sequelize, DataTypes);
+    // SQLite requires UNIQUE on any column referenced by a FK. The production
+    // Student model does not declare it (Postgres is more permissive).
+    // Patching the in-memory attribute keeps the file untouched.
+    Student.rawAttributes.wallet_address.unique = true;
+    Issuer = require("../models/issuers")(sequelize, DataTypes);
+    Recruiter = require("../models/recruiters")(sequelize, DataTypes);
+    Certificate = require("../models/certificates")(sequelize, DataTypes);
+    UserSession = require("../models/userSessions")(sequelize, DataTypes);
+    Payment = require("../models/payments")(sequelize, DataTypes);
+    TalentInvitation = require("../models/talentInvitations")(sequelize, DataTypes);
+    TreasuryTransfer = require("../models/treasuryTransfers")(sequelize, DataTypes);
+
+    const models = {
+      User, Student, Issuer, Recruiter, Certificate, UserSession,
+      Payment, TalentInvitation, TreasuryTransfer,
+    };
+    Object.values(models).forEach((model) => {
+      if (model.associate) model.associate(models);
+    });
+
+    await sequelize.sync({ force: true });
+  });
+
+  afterAll(async () => {
+    if (sequelize) await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    // Re-create every table from scratch between tests for total isolation.
+    // SQLite is fast enough that this is cheaper than chasing FK/truncate
+    // quirks across dialect differences.
+    await sequelize.sync({ force: true });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Payment
+  // ---------------------------------------------------------------------------
+
+  describe("Payment", () => {
+    test("create with required fields persists a row", async () => {
+      const payment = await Payment.create({
+        tx_hash: "0x" + "a".repeat(64),
+        from_wallet: ISSUER_WALLET,
+        amount_hack: 6900,
+        harjoot_price_usd: 0.20,
+        user_price_usd: 0.69,
+        status: "confirmed",
+        purpose: "tokenize",
+      });
+
+      expect(payment.id).toBeTruthy();
+      expect(payment.tx_hash).toBe("0x" + "a".repeat(64));
+      expect(payment.purpose).toBe("tokenize");
+    });
+
+    test("status defaults to 'confirmed' when omitted", async () => {
+      const payment = await Payment.create({
+        tx_hash: "0x" + "b".repeat(64),
+        from_wallet: ISSUER_WALLET,
+        amount_hack: 6900,
+        harjoot_price_usd: 0.20,
+        user_price_usd: 0.69,
+        purpose: "tokenize",
+      });
+
+      expect(payment.status).toBe("confirmed");
+    });
+
+    test("tx_hash is unique — duplicate insert rejected at the DB layer", async () => {
+      const tx = "0x" + "c".repeat(64);
+      await Payment.create({
+        tx_hash: tx,
+        from_wallet: ISSUER_WALLET,
+        amount_hack: 6900,
+        harjoot_price_usd: 0.20,
+        user_price_usd: 0.69,
+        purpose: "tokenize",
+      });
+
+      await expect(
+        Payment.create({
+          tx_hash: tx,
+          from_wallet: ISSUER_WALLET,
+          amount_hack: 6900,
+          harjoot_price_usd: 0.20,
+          user_price_usd: 0.69,
+          purpose: "tokenize",
+        }),
+      ).rejects.toThrow();
+    });
+
+    test("tx_hash, from_wallet, amount_hack, harjoot_price_usd, user_price_usd, purpose are all NOT NULL", async () => {
+      // Omitting any required field must reject.
+      const base = {
+        tx_hash: "0x" + "d".repeat(64),
+        from_wallet: ISSUER_WALLET,
+        amount_hack: 6900,
+        harjoot_price_usd: 0.20,
+        user_price_usd: 0.69,
+        purpose: "tokenize",
+      };
+      for (const field of Object.keys(base)) {
+        const broken = { ...base, tx_hash: base.tx_hash + field };
+        delete broken[field];
+        await expect(Payment.create(broken)).rejects.toThrow();
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // TalentInvitation
+  // ---------------------------------------------------------------------------
+
+  describe("TalentInvitation", () => {
+    let educator;
+
+    beforeEach(async () => {
+      educator = await User.create({
+        wallet_address: ISSUER_WALLET,
+        role: "issuer",
+        name: "Edu",
+        nonce: crypto.randomBytes(16).toString("hex"),
+      });
+    });
+
+    test("create with required fields persists a row defaulting to status='pending'", async () => {
+      const created = await TalentInvitation.create({
+        educator_user_id: educator.id,
+        student_wallet_address: STUDENT_WALLET,
+        email: "future-talent@example.com",
+      });
+      // Reload to verify the DB-side defaults (Sequelize leaves omitted columns
+      // as undefined on the returned instance until reloaded).
+      const invite = await TalentInvitation.findByPk(created.id);
+
+      expect(invite.id).toBeTruthy();
+      expect(invite.status).toBe("pending");
+      expect(invite.claimed_at).toBeNull();
+    });
+
+    test("belongsTo User (educator) — can be eager loaded as 'educator'", async () => {
+      await TalentInvitation.create({
+        educator_user_id: educator.id,
+        student_wallet_address: STUDENT_WALLET,
+        email: "future-talent@example.com",
+      });
+
+      const loaded = await TalentInvitation.findOne({
+        where: { student_wallet_address: STUDENT_WALLET },
+        include: [{ model: User, as: "educator" }],
+      });
+
+      expect(loaded.educator).toBeTruthy();
+      expect(loaded.educator.wallet_address).toBe(ISSUER_WALLET);
+      expect(loaded.educator.role).toBe("issuer");
+    });
+
+    test("claimed_at can be set when transitioning to 'claimed'", async () => {
+      const invite = await TalentInvitation.create({
+        educator_user_id: educator.id,
+        student_wallet_address: STUDENT_WALLET,
+        email: "t@example.com",
+      });
+
+      const claimedAt = new Date();
+      await invite.update({ status: "claimed", claimed_at: claimedAt });
+
+      const fresh = await TalentInvitation.findByPk(invite.id);
+      expect(fresh.status).toBe("claimed");
+      expect(fresh.claimed_at).toBeInstanceOf(Date);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // TreasuryTransfer
+  // ---------------------------------------------------------------------------
+
+  describe("TreasuryTransfer", () => {
+    let payment;
+
+    beforeEach(async () => {
+      payment = await Payment.create({
+        tx_hash: "0x" + "e".repeat(64),
+        from_wallet: ISSUER_WALLET,
+        amount_hack: 6900,
+        harjoot_price_usd: 0.20,
+        user_price_usd: 0.69,
+        purpose: "tokenize",
+      });
+    });
+
+    test("create with required fields defaults to destination='harjoot' and status='pending'", async () => {
+      const created = await TreasuryTransfer.create({
+        payment_id: payment.id,
+        amount_usdt_owed: 0.20,
+      });
+      const transfer = await TreasuryTransfer.findByPk(created.id);
+
+      expect(transfer.id).toBeTruthy();
+      expect(transfer.destination).toBe("harjoot");
+      expect(transfer.status).toBe("pending");
+      expect(transfer.usdt_tx_hash).toBeNull();
+      expect(transfer.sent_at).toBeNull();
+      expect(transfer.error).toBeNull();
+    });
+
+    test("belongsTo Payment — eager loads the linked payment", async () => {
+      await TreasuryTransfer.create({
+        payment_id: payment.id,
+        amount_usdt_owed: 0.20,
+      });
+
+      const transfer = await TreasuryTransfer.findOne({
+        where: { payment_id: payment.id },
+        include: [Payment],
+      });
+
+      expect(transfer.Payment).toBeTruthy();
+      expect(transfer.Payment.id).toBe(payment.id);
+      expect(transfer.Payment.tx_hash).toBe(payment.tx_hash);
+    });
+
+    test("Payment.hasOne TreasuryTransfer — eager loads from the other side", async () => {
+      await TreasuryTransfer.create({
+        payment_id: payment.id,
+        amount_usdt_owed: 0.20,
+        status: "sent",
+        usdt_tx_hash: "0xUSDT",
+        sent_at: new Date(),
+      });
+
+      const reloaded = await Payment.findByPk(payment.id, { include: [TreasuryTransfer] });
+      expect(reloaded.TreasuryTransfer).toBeTruthy();
+      expect(reloaded.TreasuryTransfer.status).toBe("sent");
+      expect(reloaded.TreasuryTransfer.usdt_tx_hash).toBe("0xUSDT");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // New columns on existing User model
+  // ---------------------------------------------------------------------------
+
+  describe("User — Harjoot columns", () => {
+    test("new columns default to null for a freshly created user", async () => {
+      const created = await User.create({
+        wallet_address: ISSUER_WALLET,
+        role: "issuer",
+        name: "Edu",
+        nonce: crypto.randomBytes(16).toString("hex"),
+      });
+      const user = await User.findByPk(created.id);
+
+      expect(user.harjoot_membership_expires_at).toBeNull();
+      expect(user.educator_approval_status).toBeNull();
+      expect(user.approved_at).toBeNull();
+      expect(user.approved_by).toBeNull();
+      expect(user.rejection_reason).toBeNull();
+    });
+
+    test("educator_approval_status can be set to pending_approval | approved | rejected", async () => {
+      const user = await User.create({
+        wallet_address: ISSUER_WALLET,
+        role: "issuer",
+        name: "Edu",
+        nonce: crypto.randomBytes(16).toString("hex"),
+      });
+
+      await user.update({ educator_approval_status: "pending_approval" });
+      expect((await User.findByPk(user.id)).educator_approval_status).toBe("pending_approval");
+
+      await user.update({
+        educator_approval_status: "approved",
+        approved_at: new Date(),
+        approved_by: user.id,
+      });
+      const approved = await User.findByPk(user.id);
+      expect(approved.educator_approval_status).toBe("approved");
+      expect(approved.approved_at).toBeInstanceOf(Date);
+      expect(approved.approved_by).toBe(user.id);
+
+      await user.update({
+        educator_approval_status: "rejected",
+        rejection_reason: "KYC failed",
+      });
+      const rejected = await User.findByPk(user.id);
+      expect(rejected.educator_approval_status).toBe("rejected");
+      expect(rejected.rejection_reason).toBe("KYC failed");
+    });
+
+    test("harjoot_membership_expires_at can be set to a future date", async () => {
+      const user = await User.create({
+        wallet_address: ISSUER_WALLET,
+        role: "student",
+        name: "Sty",
+        nonce: crypto.randomBytes(16).toString("hex"),
+      });
+
+      const future = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+      await user.update({ harjoot_membership_expires_at: future });
+
+      const fresh = await User.findByPk(user.id);
+      expect(fresh.harjoot_membership_expires_at).toBeInstanceOf(Date);
+      expect(fresh.harjoot_membership_expires_at.getTime()).toBe(future.getTime());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // New columns on existing Certificate model + Payment association
+  // ---------------------------------------------------------------------------
+
+  describe("Certificate — Harjoot columns + Payment association", () => {
+    let issuer, student, payment;
+
+    beforeEach(async () => {
+      const issuerUser = await User.create({
+        wallet_address: ISSUER_WALLET,
+        role: "issuer",
+        name: "Edu",
+        nonce: crypto.randomBytes(16).toString("hex"),
+      });
+      issuer = await Issuer.create({
+        wallet_address: ISSUER_WALLET,
+        organization_name: "Cyber Academy",
+      });
+
+      const studentUser = await User.create({
+        wallet_address: STUDENT_WALLET,
+        role: "student",
+        name: "Sty",
+        nonce: crypto.randomBytes(16).toString("hex"),
+      });
+      student = await Student.create({ wallet_address: STUDENT_WALLET });
+
+      payment = await Payment.create({
+        tx_hash: "0x" + "f".repeat(64),
+        from_wallet: ISSUER_WALLET,
+        amount_hack: 6900,
+        harjoot_price_usd: 0.20,
+        user_price_usd: 0.69,
+        purpose: "tokenize",
+      });
+    });
+
+    test("status defaults to 'issued' when omitted", async () => {
+      const cert = await Certificate.create({
+        issuer_wallet_address: ISSUER_WALLET,
+        student_wallet_address: STUDENT_WALLET,
+        title: "Intro to Sec",
+        certificate_hash: "a".repeat(64),
+        token_id: "1",
+        issue_date: "2026-01-01",
+      });
+
+      expect(cert.status).toBe("issued");
+    });
+
+    test("can persist all new Harjoot columns and the payment reference", async () => {
+      const cert = await Certificate.create({
+        issuer_wallet_address: ISSUER_WALLET,
+        student_wallet_address: STUDENT_WALLET,
+        title: "Advanced Sec",
+        certificate_hash: "b".repeat(64),
+        token_id: "2",
+        issue_date: "2026-01-01",
+        harjoot_verification_id: "HJ-P-2026-XYZ",
+        harjoot_verification_url: "https://harjoot.test/verify/HJ-P-2026-XYZ",
+        harjoot_qr_url: "https://harjoot.test/verify/HJ-P-2026-XYZ/qr",
+        payment_id: payment.id,
+        status: "issued",
+      });
+
+      expect(cert.harjoot_verification_id).toBe("HJ-P-2026-XYZ");
+      expect(cert.payment_id).toBe(payment.id);
+    });
+
+    test("belongsTo Payment — Certificate eager loads its payment", async () => {
+      await Certificate.create({
+        issuer_wallet_address: ISSUER_WALLET,
+        student_wallet_address: STUDENT_WALLET,
+        title: "Sec",
+        certificate_hash: "c".repeat(64),
+        token_id: "3",
+        issue_date: "2026-01-01",
+        payment_id: payment.id,
+      });
+
+      const reloaded = await Certificate.findOne({
+        where: { token_id: "3" },
+        include: [Payment],
+      });
+
+      expect(reloaded.Payment).toBeTruthy();
+      expect(reloaded.Payment.id).toBe(payment.id);
+    });
+
+    test("Payment.hasOne Certificate — eager loads from the payment side", async () => {
+      await Certificate.create({
+        issuer_wallet_address: ISSUER_WALLET,
+        student_wallet_address: STUDENT_WALLET,
+        title: "Sec",
+        certificate_hash: "d".repeat(64),
+        token_id: "4",
+        issue_date: "2026-01-01",
+        payment_id: payment.id,
+      });
+
+      const reloaded = await Payment.findByPk(payment.id, { include: [Certificate] });
+      expect(reloaded.Certificate).toBeTruthy();
+      expect(reloaded.Certificate.token_id).toBe("4");
+    });
+  });
+});

--- a/backend/tests/setup-env.js
+++ b/backend/tests/setup-env.js
@@ -1,0 +1,17 @@
+// backend/tests/setup-env.js
+//
+// Jest setupFiles entry — runs ONCE before any test file is loaded.
+//
+// Several modules in this codebase validate their configuration at module
+// load (middleware/auth.js — JWT_SECRET/REFRESH_SECRET; harjoot/config.js —
+// HARJOOT_API_BASE_URL/HARJOOT_PARTNER_API_KEY). When jest does the initial
+// `require` of those modules, missing env vars throw and the suite never
+// starts. We seed harmless dummy values here.
+//
+// The `||=` operator only writes when the variable is unset, so a real
+// environment (CI override, .env, a developer's terminal) always wins.
+
+process.env.JWT_SECRET              ||= "test_jwt_secret";
+process.env.REFRESH_SECRET          ||= "test_refresh_secret";
+process.env.HARJOOT_API_BASE_URL    ||= "https://test.harjoot.local";
+process.env.HARJOOT_PARTNER_API_KEY ||= "test-partner-key";


### PR DESCRIPTION
Implementation of the Harjoot Partner API integration, following the plan in
`documents/harjoot-implementation-plan.md`. PR is incremental — each phase
adds commits to this same branch until all 10 phases are complete.

## Progress

- [x] **Phase 0** — module foundations: config, typed client, mock adapter, factory, tests (48 tests)
- [x] **Phase 1** — persistence: migration script, 3 new models, columns on users/certificates, tests (17 tests)
- [ ] Phase 2 — Section 0 (partner health check)
- [ ] Phase 3 — Section 2 (membership activation hook)
- [ ] Phase 4 — Section 3 (access middleware)
- [ ] Phase 5 — Section 2.5 (educator approval)
- [ ] Phase 6 — Section 5 (talent invitation)
- [ ] Phase 7 — Section 4 (certificate issuance)
- [ ] Phase 8 — Section 13 (treasury worker)
- [ ] Phase 9 — hardening (logs, rate limits, metrics)
- [ ] Phase 10 — smoke tests against real Harjoot

## Notes

- Mock client is enabled via `HARJOOT_USE_MOCK=true` for dev without credentials.
- Migration is idempotent and runs with `npm run migrate:harjoot-phase1`.
- See `backend/harjoot/README.md` and `backend/.env.example` for setup.
