### PR TITLE
Scaffold harjoot module with config, client, and health check

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -13,6 +13,7 @@ dist-ssr
 *.local
 .env
 .env.backup
+.env.example
 
 # Editor directories and files
 .vscode/*

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -13,7 +13,6 @@ dist-ssr
 *.local
 .env
 .env.backup
-.env.example
 
 # Editor directories and files
 .vscode/*

--- a/backend/harjoot/adapters/__tests__/nftMintAdapter.test.js
+++ b/backend/harjoot/adapters/__tests__/nftMintAdapter.test.js
@@ -1,0 +1,221 @@
+// backend/harjoot/adapters/__tests__/nftMintAdapter.test.js
+//
+// Same shape as polygonProvider tests: cover the mock queue semantics,
+// factory env-driven selection, lazy singleton behavior, and the real
+// adapter's construction surface (we do not exercise live ethers calls).
+
+const ORIGINAL_ENV = { ...process.env };
+
+function loadFreshModule(envOverrides = {}) {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV, ...envOverrides };
+  return require("../nftMintAdapter");
+}
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  jest.resetModules();
+});
+
+const VALID_STUDENT = "0x1111111111111111111111111111111111111111";
+const VALID_PARAMS = {
+  studentWallet: VALID_STUDENT,
+  studentName: "Sty",
+  courseName: "Solidity 101",
+  tokenUri: "ipfs://bafy.../meta.json",
+};
+
+// ---------------------------------------------------------------------------
+// Mock adapter
+// ---------------------------------------------------------------------------
+
+describe("nftMintAdapter - mock semantics", () => {
+  test("returns a deterministic auto-generated tokenId when queue is empty", async () => {
+    const { createMockAdapter } = loadFreshModule();
+    const adapter = createMockAdapter();
+    const first = await adapter.mintCertificate(VALID_PARAMS);
+    const second = await adapter.mintCertificate(VALID_PARAMS);
+    expect(typeof first.tokenId).toBe("bigint");
+    expect(typeof first.txHash).toBe("string");
+    expect(first.tokenId).not.toBe(second.tokenId); // monotonic
+    expect(first.txHash).not.toBe(second.txHash);
+  });
+
+  test("__setNextResult is consumed once, then falls back to auto-gen", async () => {
+    const { createMockAdapter } = loadFreshModule();
+    const adapter = createMockAdapter();
+    adapter.__setNextResult({ tokenId: 42n, txHash: "0xdeadbeef" });
+
+    const first = await adapter.mintCertificate(VALID_PARAMS);
+    const second = await adapter.mintCertificate(VALID_PARAMS);
+
+    expect(first).toEqual({ tokenId: 42n, txHash: "0xdeadbeef" });
+    expect(second.tokenId).not.toBe(42n);
+  });
+
+  test("__setNextResult validates its inputs", () => {
+    const { createMockAdapter } = loadFreshModule();
+    const adapter = createMockAdapter();
+    expect(() => adapter.__setNextResult({ tokenId: 42, txHash: "0xa" })).toThrow(TypeError); // not bigint
+    expect(() => adapter.__setNextResult({ tokenId: 42n, txHash: 123 })).toThrow(TypeError);  // not string
+  });
+
+  test("__setNextError throws the queued error then resumes normal queue", async () => {
+    const { createMockAdapter } = loadFreshModule();
+    const adapter = createMockAdapter();
+    const bomb = new Error("chain rejected");
+    adapter.__setNextError(bomb);
+    adapter.__setNextResult({ tokenId: 7n, txHash: "0xabc" });
+
+    await expect(adapter.mintCertificate(VALID_PARAMS)).rejects.toBe(bomb);
+    await expect(adapter.mintCertificate(VALID_PARAMS)).resolves.toEqual({
+      tokenId: 7n,
+      txHash: "0xabc",
+    });
+  });
+
+  test("__reset clears the queue and resets the auto-id counter", async () => {
+    const { createMockAdapter } = loadFreshModule();
+    const adapter = createMockAdapter();
+    adapter.__setNextResult({ tokenId: 999n, txHash: "0x0" });
+    adapter.__setNextResult({ tokenId: 1000n, txHash: "0x1" });
+    expect(adapter.__pendingCount()).toBe(2);
+    adapter.__reset();
+    expect(adapter.__pendingCount()).toBe(0);
+
+    const after = await adapter.mintCertificate(VALID_PARAMS);
+    expect(after.tokenId).toBeGreaterThanOrEqual(1000n);
+  });
+
+  test("rejects calls with invalid params (programmer-error guard)", async () => {
+    const { createMockAdapter } = loadFreshModule();
+    const adapter = createMockAdapter();
+    await expect(adapter.mintCertificate({ ...VALID_PARAMS, studentWallet: "nope" })).rejects.toThrow(TypeError);
+    await expect(adapter.mintCertificate({ ...VALID_PARAMS, studentName: "" })).rejects.toThrow(TypeError);
+    await expect(adapter.mintCertificate({ ...VALID_PARAMS, courseName: "" })).rejects.toThrow(TypeError);
+    await expect(adapter.mintCertificate({ ...VALID_PARAMS, tokenUri: "" })).rejects.toThrow(TypeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real adapter — construction surface only
+// ---------------------------------------------------------------------------
+
+describe("nftMintAdapter - real adapter construction", () => {
+  // A throwaway private key — random bytes, not derived from any wallet.
+  const PRIVKEY = "0x" + "1".repeat(64);
+  const CONTRACT = "0x2222222222222222222222222222222222222222";
+
+  test("createRealAdapter returns an object with mintCertificate", () => {
+    const { createRealAdapter } = loadFreshModule();
+    const adapter = createRealAdapter({
+      rpcUrl: "https://polygon-rpc.example/v1",
+      privateKey: PRIVKEY,
+      contractAddress: CONTRACT,
+    });
+    expect(typeof adapter.mintCertificate).toBe("function");
+    // Mock-only helper should NOT exist on the real surface.
+    expect(adapter.__setNextResult).toBeUndefined();
+  });
+
+  test("createRealAdapter throws TypeError on missing rpcUrl", () => {
+    const { createRealAdapter } = loadFreshModule();
+    expect(() => createRealAdapter({ privateKey: PRIVKEY, contractAddress: CONTRACT })).toThrow(TypeError);
+  });
+  test("createRealAdapter throws TypeError on missing privateKey", () => {
+    const { createRealAdapter } = loadFreshModule();
+    expect(() => createRealAdapter({ rpcUrl: "https://x", contractAddress: CONTRACT })).toThrow(TypeError);
+  });
+  test("createRealAdapter throws TypeError on missing contractAddress", () => {
+    const { createRealAdapter } = loadFreshModule();
+    expect(() => createRealAdapter({ rpcUrl: "https://x", privateKey: PRIVKEY })).toThrow(TypeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Factory + lazy singleton
+// ---------------------------------------------------------------------------
+
+describe("nftMintAdapter - factory selection (CHAIN_USE_MOCK)", () => {
+  const PRIVKEY = "0x" + "1".repeat(64);
+
+  test("CHAIN_USE_MOCK=true yields the in-process mock", () => {
+    const { createNftMintAdapter } = loadFreshModule({ CHAIN_USE_MOCK: "true" });
+    const adapter = createNftMintAdapter();
+    expect(typeof adapter.__setNextResult).toBe("function");
+  });
+
+  test("CHAIN_USE_MOCK=1 also selects the mock", () => {
+    const { createNftMintAdapter } = loadFreshModule({ CHAIN_USE_MOCK: "1" });
+    const adapter = createNftMintAdapter();
+    expect(typeof adapter.__setNextResult).toBe("function");
+  });
+
+  test("real mode requires POLYGON_RPC_URL", () => {
+    const mod = loadFreshModule({
+      CHAIN_USE_MOCK: "false",
+      POLYGON_RPC_URL: "",
+      POLYGON_OWNER_PRIVATE_KEY: PRIVKEY,
+      VITE_CONTRACT_ADDRESS: "0x" + "2".repeat(40),
+    });
+    expect(() => mod.createNftMintAdapter()).toThrow(mod.NftMintError);
+    expect(() => mod.createNftMintAdapter()).toThrow(/POLYGON_RPC_URL/);
+  });
+
+  test("real mode requires POLYGON_OWNER_PRIVATE_KEY", () => {
+    const mod = loadFreshModule({
+      CHAIN_USE_MOCK: "false",
+      POLYGON_RPC_URL: "https://x",
+      POLYGON_OWNER_PRIVATE_KEY: "",
+      VITE_CONTRACT_ADDRESS: "0x" + "2".repeat(40),
+    });
+    expect(() => mod.createNftMintAdapter()).toThrow(/POLYGON_OWNER_PRIVATE_KEY/);
+  });
+
+  test("real mode requires VITE_CONTRACT_ADDRESS", () => {
+    const mod = loadFreshModule({
+      CHAIN_USE_MOCK: "false",
+      POLYGON_RPC_URL: "https://x",
+      POLYGON_OWNER_PRIVATE_KEY: PRIVKEY,
+      VITE_CONTRACT_ADDRESS: "",
+    });
+    expect(() => mod.createNftMintAdapter()).toThrow(/VITE_CONTRACT_ADDRESS/);
+  });
+
+  test("real mode constructs the real adapter when all env vars are set", () => {
+    const { createNftMintAdapter } = loadFreshModule({
+      CHAIN_USE_MOCK: "false",
+      POLYGON_RPC_URL: "https://x",
+      POLYGON_OWNER_PRIVATE_KEY: PRIVKEY,
+      VITE_CONTRACT_ADDRESS: "0x" + "2".repeat(40),
+    });
+    const adapter = createNftMintAdapter();
+    expect(adapter.__setNextResult).toBeUndefined();
+    expect(typeof adapter.mintCertificate).toBe("function");
+  });
+});
+
+describe("nftMintAdapter - lazy singleton", () => {
+  test("createNftMintAdapter memoizes after the first call", () => {
+    const { createNftMintAdapter } = loadFreshModule({ CHAIN_USE_MOCK: "true" });
+    const a = createNftMintAdapter();
+    const b = createNftMintAdapter();
+    expect(a).toBe(b);
+  });
+
+  test("__resetForTests clears the cache so a flipped env can take effect", () => {
+    const PRIVKEY = "0x" + "1".repeat(64);
+    const mod = loadFreshModule({ CHAIN_USE_MOCK: "true" });
+    const first = mod.createNftMintAdapter();
+    mod.__resetForTests();
+
+    process.env.CHAIN_USE_MOCK = "false";
+    process.env.POLYGON_RPC_URL = "https://other";
+    process.env.POLYGON_OWNER_PRIVATE_KEY = PRIVKEY;
+    process.env.VITE_CONTRACT_ADDRESS = "0x" + "3".repeat(40);
+
+    const second = mod.createNftMintAdapter();
+    expect(second).not.toBe(first);
+    expect(second.__setNextResult).toBeUndefined();
+  });
+});

--- a/backend/harjoot/adapters/__tests__/polygonProvider.test.js
+++ b/backend/harjoot/adapters/__tests__/polygonProvider.test.js
@@ -1,0 +1,134 @@
+// backend/harjoot/adapters/__tests__/polygonProvider.test.js
+//
+// Covers (a) the mock provider's queue semantics, (b) factory-level
+// selection between real and mock based on env, and (c) the lazy
+// singleton's cache + reset behavior. The real ethers JsonRpcProvider
+// is exercised at the construction surface only — its network behavior
+// is not our concern (that's ethers' test suite).
+
+const ORIGINAL_ENV = { ...process.env };
+
+function loadFreshModule(envOverrides = {}) {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV, ...envOverrides };
+  return require("../polygonProvider");
+}
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  jest.resetModules();
+});
+
+describe("polygonProvider - mock adapter semantics", () => {
+  test("returns null when nothing has been queued (unknown tx behavior)", async () => {
+    const { createMockProvider } = loadFreshModule();
+    const provider = createMockProvider();
+    await expect(provider.getTransactionReceipt("0xabc")).resolves.toBeNull();
+  });
+
+  test("returns canned receipts in FIFO order then falls back to null", async () => {
+    const { createMockProvider } = loadFreshModule();
+    const provider = createMockProvider();
+    const r1 = { status: 1, hash: "0x1" };
+    const r2 = { status: 1, hash: "0x2" };
+    provider.__setNextReceipt(r1);
+    provider.__setNextReceipt(r2);
+
+    await expect(provider.getTransactionReceipt("0xa")).resolves.toBe(r1);
+    await expect(provider.getTransactionReceipt("0xa")).resolves.toBe(r2);
+    await expect(provider.getTransactionReceipt("0xa")).resolves.toBeNull();
+  });
+
+  test("throws the queued error and keeps subsequent queue entries intact", async () => {
+    const { createMockProvider } = loadFreshModule();
+    const provider = createMockProvider();
+    const bomb = new Error("RPC blew up");
+    const r = { status: 1, hash: "0xok" };
+    provider.__setNextError(bomb);
+    provider.__setNextReceipt(r);
+
+    await expect(provider.getTransactionReceipt("0xa")).rejects.toBe(bomb);
+    await expect(provider.getTransactionReceipt("0xa")).resolves.toBe(r);
+  });
+
+  test("__reset clears the queue", async () => {
+    const { createMockProvider } = loadFreshModule();
+    const provider = createMockProvider();
+    provider.__setNextReceipt({ status: 1 });
+    provider.__setNextReceipt({ status: 1 });
+    expect(provider.__pendingCount()).toBe(2);
+    provider.__reset();
+    expect(provider.__pendingCount()).toBe(0);
+    await expect(provider.getTransactionReceipt("0xa")).resolves.toBeNull();
+  });
+});
+
+describe("polygonProvider - real adapter construction", () => {
+  test("createRealProvider returns an object with getTransactionReceipt", () => {
+    const { createRealProvider } = loadFreshModule();
+    const provider = createRealProvider({ rpcUrl: "https://polygon-rpc.example/v1" });
+    expect(typeof provider.getTransactionReceipt).toBe("function");
+  });
+
+  test("createRealProvider throws TypeError on missing rpcUrl", () => {
+    const { createRealProvider } = loadFreshModule();
+    expect(() => createRealProvider({})).toThrow(TypeError);
+    expect(() => createRealProvider({ rpcUrl: "" })).toThrow(TypeError);
+  });
+});
+
+describe("polygonProvider - factory selection (CHAIN_USE_MOCK)", () => {
+  test("CHAIN_USE_MOCK=true yields the in-process mock with test helpers", () => {
+    const { createPolygonProvider } = loadFreshModule({ CHAIN_USE_MOCK: "true" });
+    const provider = createPolygonProvider();
+    // The mock exposes __setNextReceipt; the real adapter does not.
+    expect(typeof provider.__setNextReceipt).toBe("function");
+    expect(typeof provider.__reset).toBe("function");
+  });
+
+  test("CHAIN_USE_MOCK=1 (numeric) also selects the mock", () => {
+    const { createPolygonProvider } = loadFreshModule({ CHAIN_USE_MOCK: "1" });
+    const provider = createPolygonProvider();
+    expect(typeof provider.__setNextReceipt).toBe("function");
+  });
+
+  test("real mode requires POLYGON_RPC_URL — throws PolygonProviderError when missing", () => {
+    const mod = loadFreshModule({ CHAIN_USE_MOCK: "false", POLYGON_RPC_URL: "" });
+    expect(() => mod.createPolygonProvider()).toThrow(mod.PolygonProviderError);
+    expect(() => mod.createPolygonProvider()).toThrow(/POLYGON_RPC_URL/);
+  });
+
+  test("real mode constructs the real provider when POLYGON_RPC_URL is set", () => {
+    const { createPolygonProvider } = loadFreshModule({
+      CHAIN_USE_MOCK: "false",
+      POLYGON_RPC_URL: "https://polygon-rpc.example/v1",
+    });
+    const provider = createPolygonProvider();
+    // Real adapter does NOT expose mock-only helpers.
+    expect(provider.__setNextReceipt).toBeUndefined();
+    expect(typeof provider.getTransactionReceipt).toBe("function");
+  });
+});
+
+describe("polygonProvider - lazy singleton", () => {
+  test("createPolygonProvider memoizes after the first call", () => {
+    const { createPolygonProvider } = loadFreshModule({ CHAIN_USE_MOCK: "true" });
+    const a = createPolygonProvider();
+    const b = createPolygonProvider();
+    expect(a).toBe(b);
+  });
+
+  test("__resetForTests clears the cache so a flipped env can take effect", () => {
+    const mod = loadFreshModule({ CHAIN_USE_MOCK: "true" });
+    const first = mod.createPolygonProvider();
+    mod.__resetForTests();
+    // Flip the env on the fly — Node sees it since createPolygonProvider
+    // reads process.env at call time, not at module load.
+    process.env.CHAIN_USE_MOCK = "false";
+    process.env.POLYGON_RPC_URL = "https://other-rpc.example/v1";
+    const second = mod.createPolygonProvider();
+    expect(second).not.toBe(first);
+    // Confirm the second one is the real branch (no mock helpers).
+    expect(second.__setNextReceipt).toBeUndefined();
+  });
+});

--- a/backend/harjoot/adapters/nftMintAdapter.js
+++ b/backend/harjoot/adapters/nftMintAdapter.js
@@ -1,0 +1,245 @@
+// backend/harjoot/adapters/nftMintAdapter.js
+//
+// On-chain mint adapter for the HackCertificate ERC-721. Mirrors the
+// polygonProvider pattern: a thin port surface plus a real ethers v6
+// implementation and an in-process mock for tests.
+//
+// Port:
+//   mintCertificate({ studentWallet, studentName, courseName, tokenUri })
+//     -> Promise<{ tokenId: bigint, txHash: string }>
+//
+// The contract signature (HackCertificate.sol) is
+//   issueCertificate(address to, string studentName, string courseName, string tokenUri)
+// gated by `onlyAuthorizedIssuer`. The backend's owner wallet is the
+// authorized issuer that signs every certificate mint on behalf of
+// educators — educators NEVER hold the contract's signing key.
+//
+// The tokenId is returned on-chain from the function, but JSON-RPC
+// receipts do not surface return values; we recover the id by parsing
+// the `CertificateIssued(uint256 tokenId, address indexed issuer,
+// address indexed student)` event from the receipt's logs.
+//
+// Selection: CHAIN_USE_MOCK reuses the polygonProvider switch. If chain
+// reads are mocked, chain writes should be too — keeping them coupled
+// avoids "we verified a real payment but persisted a fake mint" classes
+// of bug.
+
+const LOG_PREFIX = "[nftMintAdapter]";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+class NftMintError extends Error {
+  constructor(message, cause) {
+    super(message);
+    this.name = "NftMintError";
+    if (cause) this.cause = cause;
+  }
+}
+
+// Minimal ABI: only the function we call + the event we read. Pulling the
+// full contract ABI would couple this module to compilation artifacts we
+// don't need.
+const CONTRACT_ABI = [
+  "function issueCertificate(address to, string studentName, string courseName, string tokenUri) external returns (uint256)",
+  "event CertificateIssued(uint256 tokenId, address indexed issuer, address indexed student)",
+];
+
+const WALLET_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+function assertMintParams({ studentWallet, studentName, courseName, tokenUri }) {
+  if (typeof studentWallet !== "string" || !WALLET_REGEX.test(studentWallet)) {
+    throw new TypeError("mintCertificate requires a 0x-prefixed studentWallet");
+  }
+  if (!studentName || typeof studentName !== "string") {
+    throw new TypeError("mintCertificate requires a non-empty studentName");
+  }
+  if (!courseName || typeof courseName !== "string") {
+    throw new TypeError("mintCertificate requires a non-empty courseName");
+  }
+  if (!tokenUri || typeof tokenUri !== "string") {
+    throw new TypeError("mintCertificate requires a non-empty tokenUri");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Real adapter — ethers v6 Contract + Wallet
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {{ rpcUrl: string, privateKey: string, contractAddress: string }} opts
+ */
+function createRealAdapter({ rpcUrl, privateKey, contractAddress }) {
+  if (!rpcUrl)          throw new TypeError("createRealAdapter requires { rpcUrl }");
+  if (!privateKey)      throw new TypeError("createRealAdapter requires { privateKey }");
+  if (!contractAddress) throw new TypeError("createRealAdapter requires { contractAddress }");
+
+  const { JsonRpcProvider, Wallet, Contract, Interface } = require("ethers");
+  const provider = new JsonRpcProvider(rpcUrl);
+  const wallet   = new Wallet(privateKey, provider);
+  const contract = new Contract(contractAddress, CONTRACT_ABI, wallet);
+
+  // Cached Interface for log parsing — receipt logs are NOT auto-decoded
+  // when we send a write transaction, so we walk receipt.logs ourselves.
+  const iface = new Interface(CONTRACT_ABI);
+  const issuedTopic0 = iface.getEvent("CertificateIssued").topicHash;
+
+  return {
+    async mintCertificate(params) {
+      assertMintParams(params);
+      const { studentWallet, studentName, courseName, tokenUri } = params;
+
+      let receipt;
+      try {
+        const tx = await contract.issueCertificate(studentWallet, studentName, courseName, tokenUri);
+        receipt = await tx.wait();
+      } catch (err) {
+        throw new NftMintError(
+          `issueCertificate failed for student=${studentWallet}: ${err.message || err}`,
+          err,
+        );
+      }
+
+      if (!receipt || Number(receipt.status) !== 1) {
+        throw new NftMintError(
+          `issueCertificate tx reverted (status=${receipt && receipt.status})`,
+        );
+      }
+
+      // Find the CertificateIssued event emitted by OUR contract address.
+      const log = (receipt.logs || []).find((l) => {
+        if (!l || !l.address || !Array.isArray(l.topics)) return false;
+        if (l.address.toLowerCase() !== contractAddress.toLowerCase()) return false;
+        return l.topics[0] === issuedTopic0;
+      });
+      if (!log) {
+        throw new NftMintError(
+          "issueCertificate succeeded on-chain but no CertificateIssued event was found in the receipt",
+        );
+      }
+
+      let parsed;
+      try {
+        parsed = iface.parseLog({ topics: log.topics, data: log.data });
+      } catch (err) {
+        throw new NftMintError("Failed to decode CertificateIssued event", err);
+      }
+
+      const tokenId = BigInt(parsed.args.tokenId);
+      const txHash  = receipt.hash || receipt.transactionHash;
+      console.log(`${LOG_PREFIX} minted tokenId=${tokenId} tx=${txHash} student=${studentWallet}`);
+      return { tokenId, txHash };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock adapter — for tests and offline dev
+// ---------------------------------------------------------------------------
+
+/**
+ * In-process mock. FIFO queue of canned responses; each successful call
+ * consumes one entry. If the queue is empty, returns a deterministic
+ * default so tests that don't care about the exact id don't have to
+ * preload anything.
+ */
+function createMockAdapter() {
+  const queue = []; // { type: "ok", tokenId, txHash } | { type: "error", value }
+  let autoTokenId = 1000n;
+
+  return {
+    async mintCertificate(params) {
+      assertMintParams(params);
+      const next = queue.shift();
+      if (next && next.type === "error") throw next.value;
+      if (next && next.type === "ok") return { tokenId: next.tokenId, txHash: next.txHash };
+      // Auto-generated default. Increments so back-to-back calls produce
+      // distinct ids; keeps tests that mint several certs realistic.
+      autoTokenId += 1n;
+      return {
+        tokenId: autoTokenId,
+        txHash: "0x" + autoTokenId.toString(16).padStart(64, "0"),
+      };
+    },
+
+    __setNextResult({ tokenId, txHash }) {
+      if (typeof tokenId !== "bigint") throw new TypeError("tokenId must be bigint");
+      if (typeof txHash !== "string")  throw new TypeError("txHash must be string");
+      queue.push({ type: "ok", tokenId, txHash });
+    },
+    __setNextError(err) {
+      queue.push({ type: "error", value: err });
+    },
+    __reset() {
+      queue.length = 0;
+      autoTokenId = 1000n;
+    },
+    __pendingCount() {
+      return queue.length;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory + lazy singleton
+// ---------------------------------------------------------------------------
+
+let cached = null;
+
+function isMockMode() {
+  const v = process.env.CHAIN_USE_MOCK;
+  return v === "true" || v === "1";
+}
+
+/**
+ * Lazy singleton. Mirrors polygonProvider — env is not validated until
+ * first call, so importing this module is safe in mock-only environments.
+ */
+function createNftMintAdapter() {
+  if (cached) return cached;
+
+  if (isMockMode()) {
+    console.log(`${LOG_PREFIX} using mock adapter (CHAIN_USE_MOCK=true)`);
+    cached = createMockAdapter();
+    return cached;
+  }
+
+  // Real mode — every signer var must be present; refuse to silently
+  // degrade. Naming intentionally matches services/authorizeIssuer.js
+  // so a single owner wallet handles both authorize and mint.
+  const rpcUrl          = process.env.POLYGON_RPC_URL;
+  const privateKey      = process.env.POLYGON_OWNER_PRIVATE_KEY;
+  const contractAddress = process.env.VITE_CONTRACT_ADDRESS;
+
+  if (!rpcUrl) {
+    throw new NftMintError(
+      "POLYGON_RPC_URL is required (or set CHAIN_USE_MOCK=true)",
+    );
+  }
+  if (!privateKey) {
+    throw new NftMintError(
+      "POLYGON_OWNER_PRIVATE_KEY is required (or set CHAIN_USE_MOCK=true)",
+    );
+  }
+  if (!contractAddress) {
+    throw new NftMintError(
+      "VITE_CONTRACT_ADDRESS is required (or set CHAIN_USE_MOCK=true)",
+    );
+  }
+
+  cached = createRealAdapter({ rpcUrl, privateKey, contractAddress });
+  return cached;
+}
+
+function __resetForTests() {
+  cached = null;
+}
+
+module.exports = {
+  createNftMintAdapter,
+  createRealAdapter,
+  createMockAdapter,
+  NftMintError,
+  __resetForTests,
+};

--- a/backend/harjoot/adapters/polygonProvider.js
+++ b/backend/harjoot/adapters/polygonProvider.js
@@ -1,0 +1,170 @@
+// backend/harjoot/adapters/polygonProvider.js
+//
+// Thin port-adapter wrapper around ethers v6 JsonRpcProvider. The point
+// of this module is NOT to abstract every RPC method ethers exposes — it
+// is to give the rest of the codebase a stable, easily-mockable surface
+// for the chain reads we actually do.
+//
+// Contract (the "port"):
+//   {
+//     getTransactionReceipt(txHash: string): Promise<Receipt | null>
+//   }
+//
+// A receipt of `null` means "the transaction is unknown to the node or
+// not yet mined". Callers MUST treat null as a soft failure, not a hard
+// one — never crash on a missing receipt.
+//
+// Selection:
+//   CHAIN_USE_MOCK=true  -> in-process mock provider (tests, dev without RPC).
+//   otherwise            -> real ethers JsonRpcProvider pointed at
+//                           process.env.POLYGON_RPC_URL.
+//
+// Pattern note: HARJOOT_USE_MOCK and CHAIN_USE_MOCK are intentionally
+// SEPARATE flags. You may want a real Harjoot partner endpoint while
+// hitting a local Anvil for chain reads, or vice versa, so we don't
+// couple them.
+
+const LOG_PREFIX = "[polygonProvider]";
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+class PolygonProviderError extends Error {
+  constructor(message, cause) {
+    super(message);
+    this.name = "PolygonProviderError";
+    if (cause) this.cause = cause;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Real adapter — ethers v6 JsonRpcProvider
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct a real provider. Exported separately so tests can build one
+ * against a local Anvil node without going through the singleton factory.
+ *
+ * @param {{ rpcUrl: string }} opts
+ */
+function createRealProvider({ rpcUrl }) {
+  if (!rpcUrl || typeof rpcUrl !== "string") {
+    throw new TypeError("createRealProvider requires { rpcUrl: string }");
+  }
+  // Lazy-require so the ethers cost is only paid when this branch runs.
+  // Keeps test boot fast and avoids loading native deps in mock-only envs.
+  const { JsonRpcProvider } = require("ethers");
+  const provider = new JsonRpcProvider(rpcUrl);
+
+  return {
+    /**
+     * @param {string} txHash 0x-prefixed transaction hash.
+     * @returns {Promise<object | null>} ethers v6 TransactionReceipt or null.
+     */
+    async getTransactionReceipt(txHash) {
+      try {
+        return await provider.getTransactionReceipt(txHash);
+      } catch (err) {
+        // Network / RPC errors surface as PolygonProviderError so callers
+        // can distinguish "infra is down" from "tx not found".
+        throw new PolygonProviderError(
+          `RPC error fetching receipt for ${txHash}: ${err.message || err}`,
+          err,
+        );
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock adapter — for tests and offline dev
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct an in-process mock. Returns the canned receipt set via
+ * __setNextReceipt() on the next call, or throws the canned error set
+ * via __setNextError(). Each call consumes its canned value, so multiple
+ * call expectations require multiple sets.
+ */
+function createMockProvider() {
+  const queue = []; // array of { type: "receipt" | "error", value }
+
+  return {
+    async getTransactionReceipt(_txHash) {
+      const next = queue.shift();
+      if (!next) {
+        // Default: behave like a node that has never heard of this tx.
+        return null;
+      }
+      if (next.type === "error") throw next.value;
+      return next.value;
+    },
+
+    // Test helpers — prefixed with __ to mark them as internal.
+    __setNextReceipt(receipt) {
+      queue.push({ type: "receipt", value: receipt });
+    },
+    __setNextError(err) {
+      queue.push({ type: "error", value: err });
+    },
+    __reset() {
+      queue.length = 0;
+    },
+    __pendingCount() {
+      return queue.length;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Factory + lazy singleton
+// ---------------------------------------------------------------------------
+
+let cached = null;
+
+function isMockMode() {
+  const v = process.env.CHAIN_USE_MOCK;
+  return v === "true" || v === "1";
+}
+
+/**
+ * Returns a cached provider instance. Created lazily on first call so
+ * importing this module does NOT validate env (mirrors the harjoot client
+ * pattern at harjoot/client/index.js).
+ */
+function createPolygonProvider() {
+  if (cached) return cached;
+
+  if (isMockMode()) {
+    console.log(`${LOG_PREFIX} using mock provider (CHAIN_USE_MOCK=true)`);
+    cached = createMockProvider();
+    return cached;
+  }
+
+  if (!process.env.POLYGON_RPC_URL) {
+    throw new PolygonProviderError(
+      "POLYGON_RPC_URL environment variable is required " +
+        "(or set CHAIN_USE_MOCK=true to run against the in-process mock)",
+    );
+  }
+
+  cached = createRealProvider({ rpcUrl: process.env.POLYGON_RPC_URL });
+  return cached;
+}
+
+/**
+ * Drop the cached singleton. Intended for tests that need to flip
+ * CHAIN_USE_MOCK between cases.
+ */
+function __resetForTests() {
+  cached = null;
+}
+
+module.exports = {
+  createPolygonProvider,
+  createRealProvider,
+  createMockProvider,
+  PolygonProviderError,
+  __resetForTests,
+};

--- a/backend/harjoot/client/__tests__/httpClient.correlation.test.js
+++ b/backend/harjoot/client/__tests__/httpClient.correlation.test.js
@@ -1,0 +1,205 @@
+// backend/harjoot/client/__tests__/httpClient.correlation.test.js
+//
+// Focused tests for Phase 9a structured logging + correlation propagation.
+// Reuses the fake-axios harness shape from httpClient.test.js but kept
+// separate so the original suite stays focused on the wire contract.
+
+jest.mock("axios");
+const axios = require("axios");
+
+const { createHttpClient } = require("../httpClient");
+const { runWithCorrelationId } = require("../../../lib/correlationContext");
+
+const testConfig = Object.freeze({
+  api: Object.freeze({
+    baseUrl: "https://harjoot.test/api/partner/hackchain/v1",
+    apiKey: "test-key-xyz",
+    timeoutMs: 1000,
+    maxRetries: 1,
+    retryBaseDelayMs: 1,
+  }),
+});
+
+// Same fake axios shim as httpClient.test.js but trimmed to what we need.
+function buildFakeAxiosInstance() {
+  const requestHandlers = [];
+  const responseHandlers = [];
+  const seenConfigs = [];
+  let impl = null;
+
+  async function callable(config) {
+    let cfg = config;
+    for (const handler of requestHandlers) cfg = handler(cfg);
+    seenConfigs.push(cfg);
+    let result;
+    try {
+      result = await impl(cfg);
+    } catch (err) {
+      for (const { err: errHandler } of responseHandlers) {
+        if (errHandler) {
+          try { return await errHandler(err); } catch (e) { err = e; }
+        }
+      }
+      throw err;
+    }
+    for (const { ok } of responseHandlers) if (ok) result = ok(result);
+    return result;
+  }
+  callable.get = (url, opts = {}) =>
+    callable({ method: "get", url, ...opts, headers: { ...(callable._headers || {}) } });
+  callable.post = (url, data, opts = {}) =>
+    callable({ method: "post", url, data, ...opts, headers: { ...(callable._headers || {}) } });
+  callable.interceptors = {
+    request: { use(fn) { requestHandlers.push(fn); } },
+    response: { use(ok, err) { responseHandlers.push({ ok, err }); } },
+  };
+  callable._setImpl = (fn) => { impl = fn; };
+  callable._setHeaders = (h) => { callable._headers = h; };
+  callable._seenConfigs = seenConfigs;
+  return callable;
+}
+
+let fakeAxios;
+let logSpy;
+let warnSpy;
+let errorSpy;
+
+beforeEach(() => {
+  fakeAxios = buildFakeAxiosInstance();
+  axios.create.mockImplementation((createOpts) => {
+    fakeAxios._setHeaders(createOpts.headers);
+    return fakeAxios;
+  });
+  logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+  warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers — parse the JSON payload from a `[harjoot] {...}` log line.
+// ---------------------------------------------------------------------------
+
+function parseLogLines(spy) {
+  return spy.mock.calls.map((args) => args[0]).filter((line) => {
+    return typeof line === "string" && line.startsWith("[harjoot] {");
+  }).map((line) => JSON.parse(line.slice("[harjoot] ".length)));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("httpClient — correlation propagation", () => {
+  test("adds X-Correlation-ID to outgoing axios config when a context is active", async () => {
+    fakeAxios._setImpl(async (cfg) => ({ status: 200, config: cfg, data: { ok: true } }));
+    const client = createHttpClient(testConfig);
+
+    await runWithCorrelationId("req-test-abc", async () => {
+      await client.getPartnerInfo();
+    });
+
+    const cfg = fakeAxios._seenConfigs[0];
+    expect(cfg.headers["X-Correlation-ID"]).toBe("req-test-abc");
+  });
+
+  test("omits X-Correlation-ID when no context is active", async () => {
+    fakeAxios._setImpl(async (cfg) => ({ status: 200, config: cfg, data: { ok: true } }));
+    const client = createHttpClient(testConfig);
+
+    await client.getPartnerInfo();
+
+    const cfg = fakeAxios._seenConfigs[0];
+    expect(cfg.headers["X-Correlation-ID"]).toBeUndefined();
+  });
+});
+
+describe("httpClient — structured logging", () => {
+  test("emits a request log with method, url, correlation_id and retry_count=0", async () => {
+    fakeAxios._setImpl(async (cfg) => ({ status: 200, config: cfg, data: { ok: true } }));
+    const client = createHttpClient(testConfig);
+
+    await runWithCorrelationId("req-log-1", async () => {
+      await client.getPartnerInfo();
+    });
+
+    const events = parseLogLines(logSpy);
+    const req = events.find((e) => e.event === "harjoot_request");
+    expect(req).toBeDefined();
+    expect(req.method).toBe("GET");
+    expect(req.url).toBe("/partners/me");
+    expect(req.correlation_id).toBe("req-log-1");
+    expect(req.retry_count).toBe(0);
+    // x-api-key MUST NOT appear in logged headers.
+    const headerKeys = Object.keys(req.headers || {}).map((k) => k.toLowerCase());
+    expect(headerKeys).not.toContain("x-api-key");
+  });
+
+  test("emits a response log with status and latency_ms", async () => {
+    fakeAxios._setImpl(async (cfg) => ({ status: 200, config: cfg, data: { ok: true } }));
+    const client = createHttpClient(testConfig);
+
+    await runWithCorrelationId("req-log-2", async () => {
+      await client.getPartnerInfo();
+    });
+
+    const events = parseLogLines(logSpy);
+    const resp = events.find((e) => e.event === "harjoot_response");
+    expect(resp).toBeDefined();
+    expect(resp.status).toBe(200);
+    expect(resp.correlation_id).toBe("req-log-2");
+    expect(typeof resp.latency_ms).toBe("number");
+    expect(resp.latency_ms).toBeGreaterThanOrEqual(0);
+  });
+
+  test("emits a retry log with retry_count incremented on a 500", async () => {
+    let callIdx = 0;
+    fakeAxios._setImpl(async (cfg) => {
+      callIdx += 1;
+      if (callIdx === 1) {
+        const err = new Error("server boom");
+        err.response = { status: 503, data: { error: "down" } };
+        err.config = cfg;
+        throw err;
+      }
+      return { status: 200, config: cfg, data: { ok: true } };
+    });
+    const client = createHttpClient(testConfig);
+
+    await runWithCorrelationId("req-retry", async () => {
+      await client.getPartnerInfo();
+    });
+
+    const warnEvents = parseLogLines(warnSpy);
+    const retry = warnEvents.find((e) => e.event === "harjoot_retry");
+    expect(retry).toBeDefined();
+    expect(retry.status).toBe(503);
+    expect(retry.retry_count).toBe(1);
+    expect(retry.correlation_id).toBe("req-retry");
+    expect(typeof retry.delay_ms).toBe("number");
+  });
+
+  test("emits a structured error log on a non-retryable failure", async () => {
+    fakeAxios._setImpl(async (cfg) => {
+      const err = new Error("bad request");
+      err.response = { status: 400, data: { error: "validation" } };
+      err.config = cfg;
+      throw err;
+    });
+    const client = createHttpClient(testConfig);
+
+    await runWithCorrelationId("req-400", async () => {
+      await expect(client.getPartnerInfo()).rejects.toBeDefined();
+    });
+
+    const errEvents = parseLogLines(errorSpy);
+    const errEvent = errEvents.find((e) => e.event === "harjoot_error");
+    expect(errEvent).toBeDefined();
+    expect(errEvent.status).toBe(400);
+    expect(errEvent.correlation_id).toBe("req-400");
+    expect(errEvent.error_name).toBeTruthy();
+  });
+});

--- a/backend/harjoot/client/httpClient.js
+++ b/backend/harjoot/client/httpClient.js
@@ -12,8 +12,20 @@
 const axios = require("axios");
 const defaultConfig = require("../config");
 const { HarjootError, mapAxiosErrorToHarjootError } = require("./errors");
+const { getCorrelationId } = require("../../lib/correlationContext");
 
 const LOG_PREFIX = "[harjoot]";
+const CORRELATION_HEADER = "X-Correlation-ID";
+
+// Emit a single-line JSON event behind the [harjoot] prefix. Designed for
+// log shippers (Loki, Datadog, CloudWatch) that index structured fields
+// while staying readable for humans grepping the terminal.
+function logEvent(level, fields) {
+  const line = `${LOG_PREFIX} ${JSON.stringify(fields)}`;
+  if (level === "error") console.error(line);
+  else if (level === "warn") console.warn(line);
+  else console.log(line);
+}
 
 // HackChain stores roles as student/issuer/recruiter; Harjoot expects the
 // user-facing segment talent/educator/recruiter.
@@ -65,21 +77,46 @@ function buildAxiosInstance(config) {
   });
 
   instance.interceptors.request.use((reqConfig) => {
-    console.log(
-      `${LOG_PREFIX} ${(reqConfig.method || "get").toUpperCase()} ${reqConfig.url}`,
-      { headers: sanitizeHeaders(reqConfig.headers) },
-    );
+    // Propagate the current correlation ID to Harjoot so they can join their
+    // logs to ours when reconciling an incident.
+    const correlationId = getCorrelationId();
+    if (correlationId) {
+      reqConfig.headers = reqConfig.headers || {};
+      reqConfig.headers[CORRELATION_HEADER] = correlationId;
+    }
+    // Stamp the start time on the request so the response interceptor can
+    // compute latency without juggling closures.
+    reqConfig._startMs = Date.now();
+    logEvent("info", {
+      event: "harjoot_request",
+      method: (reqConfig.method || "get").toUpperCase(),
+      url: reqConfig.url,
+      correlation_id: correlationId || null,
+      retry_count: reqConfig._retryCount || 0,
+      headers: sanitizeHeaders(reqConfig.headers),
+    });
     return reqConfig;
   });
 
   instance.interceptors.response.use(
     (response) => {
-      console.log(`${LOG_PREFIX} ${response.status} ${response.config.url}`);
+      const reqConfig = response.config || {};
+      const latency = reqConfig._startMs ? Date.now() - reqConfig._startMs : null;
+      logEvent("info", {
+        event: "harjoot_response",
+        method: (reqConfig.method || "get").toUpperCase(),
+        url: reqConfig.url,
+        status: response.status,
+        latency_ms: latency,
+        correlation_id: getCorrelationId() || null,
+        retry_count: reqConfig._retryCount || 0,
+      });
       return response;
     },
     async (axiosError) => {
       const reqConfig = axiosError.config || {};
       reqConfig._retryCount = reqConfig._retryCount || 0;
+      const latency = reqConfig._startMs ? Date.now() - reqConfig._startMs : null;
 
       const isNetworkError = !axiosError.response;
       const isServerError = axiosError.response && axiosError.response.status >= 500;
@@ -88,16 +125,34 @@ function buildAxiosInstance(config) {
       if (retryable && reqConfig._retryCount < config.api.maxRetries) {
         reqConfig._retryCount += 1;
         const delay = config.api.retryBaseDelayMs * reqConfig._retryCount;
-        console.warn(
-          `${LOG_PREFIX} retry ${reqConfig._retryCount}/${config.api.maxRetries}` +
-            ` in ${delay}ms — ${axiosError.message}`,
-        );
+        logEvent("warn", {
+          event: "harjoot_retry",
+          method: (reqConfig.method || "get").toUpperCase(),
+          url: reqConfig.url,
+          status: axiosError.response ? axiosError.response.status : null,
+          latency_ms: latency,
+          correlation_id: getCorrelationId() || null,
+          retry_count: reqConfig._retryCount,
+          max_retries: config.api.maxRetries,
+          delay_ms: delay,
+          error: axiosError.message,
+        });
         await new Promise((resolve) => setTimeout(resolve, delay));
         return instance(reqConfig);
       }
 
       const mapped = mapAxiosErrorToHarjootError(axiosError);
-      console.error(`${LOG_PREFIX} ${mapped.name} — ${mapped.message}`);
+      logEvent("error", {
+        event: "harjoot_error",
+        method: (reqConfig.method || "get").toUpperCase(),
+        url: reqConfig.url,
+        status: axiosError.response ? axiosError.response.status : null,
+        latency_ms: latency,
+        correlation_id: getCorrelationId() || null,
+        retry_count: reqConfig._retryCount,
+        error_name: mapped.name,
+        error: mapped.message,
+      });
       throw mapped;
     },
   );

--- a/backend/harjoot/config.js
+++ b/backend/harjoot/config.js
@@ -13,15 +13,33 @@
 require("dotenv").config();
 
 // ---------------------------------------------------------------------------
-// Required variables — server must not start without these
+// Mock mode — checked first because it gates the credential requirement.
+// In production this should NEVER be true; in dev/test it lets the backend
+// boot without real Harjoot credentials (uses the in-process mock client).
 // ---------------------------------------------------------------------------
 
-if (!process.env.HARJOOT_API_BASE_URL) {
-  throw new Error("HARJOOT_API_BASE_URL environment variable is required");
-}
+const USE_MOCK = (process.env.HARJOOT_USE_MOCK === "true" || process.env.HARJOOT_USE_MOCK === "1");
 
-if (!process.env.HARJOOT_PARTNER_API_KEY) {
-  throw new Error("HARJOOT_PARTNER_API_KEY environment variable is required");
+// ---------------------------------------------------------------------------
+// Required variables — only when talking to the REAL Harjoot API.
+// When HARJOOT_USE_MOCK=true the in-process mock client takes over and these
+// values are never read, so we skip validation to keep dev frictionless.
+// ---------------------------------------------------------------------------
+
+if (!USE_MOCK) {
+  if (!process.env.HARJOOT_API_BASE_URL) {
+    throw new Error(
+      "HARJOOT_API_BASE_URL environment variable is required " +
+        "(or set HARJOOT_USE_MOCK=true to run the backend with the mock client)",
+    );
+  }
+
+  if (!process.env.HARJOOT_PARTNER_API_KEY) {
+    throw new Error(
+      "HARJOOT_PARTNER_API_KEY environment variable is required " +
+        "(or set HARJOOT_USE_MOCK=true to run the backend with the mock client)",
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -65,7 +83,7 @@ const config = Object.freeze({
   }),
 
   // Runtime flags
-  useMock: parseBool(process.env.HARJOOT_USE_MOCK, false),
+  useMock: USE_MOCK,
 });
 
 module.exports = config;

--- a/backend/harjoot/config.js
+++ b/backend/harjoot/config.js
@@ -110,6 +110,12 @@ const config = Object.freeze({
   chain: Object.freeze({
     treasuryAddress:  validateAddress("TREASURY_ADDRESS", process.env.TREASURY_ADDRESS),
     hackTokenAddress: validateAddress("HACK_TOKEN_ADDRESS", process.env.HACK_TOKEN_ADDRESS),
+    // ERC-20 decimals for the HACK token. Default 18 (standard). Override
+    // via HACK_TOKEN_DECIMALS if the deployed token uses a non-standard
+    // value. Used to convert between "whole HACK" (what calculateMintPrice
+    // returns and what `payments.amount_hack` stores) and on-chain base
+    // units in Transfer event values.
+    hackTokenDecimals: parseIntWithDefault(process.env.HACK_TOKEN_DECIMALS, 18, "HACK_TOKEN_DECIMALS"),
   }),
 
   // Runtime flags

--- a/backend/harjoot/config.js
+++ b/backend/harjoot/config.js
@@ -40,6 +40,29 @@ if (!USE_MOCK) {
         "(or set HARJOOT_USE_MOCK=true to run the backend with the mock client)",
     );
   }
+
+  if (!process.env.TREASURY_ADDRESS) {
+    throw new Error(
+      "TREASURY_ADDRESS environment variable is required " +
+        "(or set HARJOOT_USE_MOCK=true to run the backend with the mock client)",
+    );
+  }
+
+  if (!process.env.HACK_TOKEN_ADDRESS) {
+    throw new Error(
+      "HACK_TOKEN_ADDRESS environment variable is required " +
+        "(or set HARJOOT_USE_MOCK=true to run the backend with the mock client)",
+    );
+  }
+}
+
+// Validate address format when present (real or mock). 0x followed by 40 hex.
+function validateAddress(name, value) {
+  if (!value) return null;
+  if (!/^0x[a-fA-F0-9]{40}$/.test(value)) {
+    throw new Error(`${name} must be a 0x-prefixed 40-hex-char address (got "${value}")`);
+  }
+  return value.toLowerCase();
 }
 
 // ---------------------------------------------------------------------------
@@ -80,6 +103,13 @@ const config = Object.freeze({
     harjootCostUsdCents:  parseIntWithDefault(process.env.HARJOOT_PRICE_USD_CENTS, 20, "HARJOOT_PRICE_USD_CENTS"),
     userPriceUsdCents:    parseIntWithDefault(process.env.USER_PRICE_USD_CENTS, 69, "USER_PRICE_USD_CENTS"),
     hackPriceUsdMicros:   parseIntWithDefault(process.env.HACK_PRICE_USD_MICROS, 100, "HACK_PRICE_USD_MICROS"),
+  }),
+
+  // On-chain addresses. Stored lowercased so equality checks against decoded
+  // transfer logs are consistent regardless of input casing.
+  chain: Object.freeze({
+    treasuryAddress:  validateAddress("TREASURY_ADDRESS", process.env.TREASURY_ADDRESS),
+    hackTokenAddress: validateAddress("HACK_TOKEN_ADDRESS", process.env.HACK_TOKEN_ADDRESS),
   }),
 
   // Runtime flags

--- a/backend/harjoot/strategies/IConversionStrategy.js
+++ b/backend/harjoot/strategies/IConversionStrategy.js
@@ -1,0 +1,69 @@
+// backend/harjoot/strategies/IConversionStrategy.js
+//
+// Documentation-only "interface" for the HACK -> USDT conversion step
+// of the treasury worker. JavaScript has no enforced interfaces; this
+// file exists so every concrete strategy points back at the same
+// contract and reviewers can spot drift quickly.
+//
+// All concrete strategies (manualConversion, dexSwapConversion,
+// burnRedeemConversion) MUST export a function named `convert` that
+// honors the shape below. The factory in ./factory.js performs a shape
+// check at startup so a misconfigured deploy fails loudly instead of
+// silently swallowing a treasury batch.
+//
+// ---------------------------------------------------------------------------
+// Conceptual contract
+// ---------------------------------------------------------------------------
+//
+//   convert({ hackAmount, models?, sequelize? }) -> Promise<ConversionResult>
+//
+//   ConversionResult is a discriminated object:
+//
+//     | { mode: "manual",      awaitingManual: true }                 // no on-chain action
+//     | { mode: "swap",        usdtAmount: bigint, txHash: string,
+//                              costs: { gasUsd?: number, slippageUsd?: number } }
+//     | { mode: "burn_redeem", usdtAmount: bigint, txHash: string,
+//                              costs: { gasUsd?: number } }
+//
+// `hackAmount` is a positive bigint in WHOLE HACK units (NOT base units —
+// the worker aggregates the queue's amount_hack column, which already
+// stores whole tokens). Strategies that touch the chain are responsible
+// for scaling to base units before signing transactions.
+//
+// `usdtAmount` is a bigint in USDT base units (6 decimals on Polygon —
+// Tether's standard). Caller can format for human display by dividing
+// by 10n**6n.
+//
+// Failure semantics: strategies throw to indicate a hard failure. The
+// worker catches and marks the affected rows as `failed` with the
+// error message. They MUST NOT silently return a malformed result.
+
+// Re-exported as a typedef so other modules can import it for JSDoc.
+/**
+ * @typedef {Object} ConversionResult
+ * @property {"manual"|"swap"|"burn_redeem"} mode
+ * @property {boolean}  [awaitingManual]  Only set for `mode: "manual"`.
+ * @property {bigint}   [usdtAmount]      USDT base units (6 decimals).
+ * @property {string}   [txHash]          On-chain settlement hash.
+ * @property {Object}   [costs]
+ * @property {number}   [costs.gasUsd]
+ * @property {number}   [costs.slippageUsd]
+ */
+
+/**
+ * Shape-check a strategy at registration time. Throws if the strategy is
+ * missing a `convert(...)` function. Kept in this file so the contract
+ * lives alongside its enforcement.
+ *
+ * @param {string} name
+ * @param {object} strategy
+ */
+function assertIsConversionStrategy(name, strategy) {
+  if (!strategy || typeof strategy.convert !== "function") {
+    throw new TypeError(
+      `${name} does not implement IConversionStrategy: missing convert(...) function`,
+    );
+  }
+}
+
+module.exports = { assertIsConversionStrategy };

--- a/backend/harjoot/strategies/__tests__/strategies.test.js
+++ b/backend/harjoot/strategies/__tests__/strategies.test.js
@@ -1,0 +1,143 @@
+// backend/harjoot/strategies/__tests__/strategies.test.js
+//
+// Covers (a) the manual strategy (the only real one for launch),
+// (b) the two stubs (must throw NOT_IMPLEMENTED to prevent silent
+// settlements), (c) the IConversionStrategy shape assertion, and
+// (d) the factory's env-driven selection.
+
+const ORIGINAL_ENV = { ...process.env };
+
+function loadFreshFactory(envOverrides = {}) {
+  jest.resetModules();
+  process.env = { ...ORIGINAL_ENV, ...envOverrides };
+  return require("../factory");
+}
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  jest.resetModules();
+});
+
+beforeAll(() => {
+  jest.spyOn(console, "log").mockImplementation(() => {});
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterAll(() => jest.restoreAllMocks());
+
+// ---------------------------------------------------------------------------
+// manualConversion
+// ---------------------------------------------------------------------------
+
+describe("manualConversion", () => {
+  const { convert } = require("../manualConversion");
+
+  test("returns { mode: 'manual', awaitingManual: true } for any positive hackAmount", async () => {
+    const result = await convert({ hackAmount: 6900n });
+    expect(result).toEqual({ mode: "manual", awaitingManual: true });
+  });
+
+  test("throws TypeError when hackAmount is not a positive bigint", async () => {
+    await expect(convert({ hackAmount: 0n })).rejects.toThrow(TypeError);
+    await expect(convert({ hackAmount: -1n })).rejects.toThrow(TypeError);
+    await expect(convert({ hackAmount: 6900 })).rejects.toThrow(TypeError); // number, not bigint
+    await expect(convert({})).rejects.toThrow(TypeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stubs — MUST throw, never silently succeed
+// ---------------------------------------------------------------------------
+
+describe("conversion stubs", () => {
+  test("dexSwapConversion throws NOT_IMPLEMENTED", async () => {
+    const { convert } = require("../dexSwapConversion");
+    await expect(convert({ hackAmount: 6900n })).rejects.toThrow(/not implemented/i);
+  });
+
+  test("burnRedeemConversion throws NOT_IMPLEMENTED", async () => {
+    const { convert } = require("../burnRedeemConversion");
+    await expect(convert({ hackAmount: 6900n })).rejects.toThrow(/not implemented/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IConversionStrategy shape check
+// ---------------------------------------------------------------------------
+
+describe("assertIsConversionStrategy", () => {
+  const { assertIsConversionStrategy } = require("../IConversionStrategy");
+
+  test("accepts a strategy with a convert function", () => {
+    expect(() => assertIsConversionStrategy("ok", { convert: () => {} })).not.toThrow();
+  });
+
+  test("throws when convert is missing", () => {
+    expect(() => assertIsConversionStrategy("broken", {})).toThrow(TypeError);
+    expect(() => assertIsConversionStrategy("nope", null)).toThrow(TypeError);
+    expect(() => assertIsConversionStrategy("notFunc", { convert: 42 })).toThrow(TypeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+describe("factory.selectStrategy", () => {
+  test("defaults to manual when TREASURY_CONVERSION_MODE is unset", () => {
+    const factory = loadFreshFactory({ TREASURY_CONVERSION_MODE: "" });
+    const { mode, strategy } = factory.selectStrategy();
+    expect(mode).toBe("manual");
+    expect(typeof strategy.convert).toBe("function");
+  });
+
+  test("explicit 'manual' selects manualConversion", () => {
+    const factory = loadFreshFactory();
+    const { mode, strategy } = factory.selectStrategy("manual");
+    expect(mode).toBe("manual");
+    // It's the same module as ../manualConversion exports.
+    expect(strategy).toBe(require("../manualConversion"));
+  });
+
+  test("'swap' selects dexSwapConversion", () => {
+    const factory = loadFreshFactory();
+    const { mode, strategy } = factory.selectStrategy("swap");
+    expect(mode).toBe("swap");
+    expect(strategy).toBe(require("../dexSwapConversion"));
+  });
+
+  test("'burn_redeem' selects burnRedeemConversion", () => {
+    const factory = loadFreshFactory();
+    const { mode, strategy } = factory.selectStrategy("burn_redeem");
+    expect(mode).toBe("burn_redeem");
+    expect(strategy).toBe(require("../burnRedeemConversion"));
+  });
+
+  test("env-driven selection picks up TREASURY_CONVERSION_MODE", () => {
+    const factory = loadFreshFactory({ TREASURY_CONVERSION_MODE: "swap" });
+    expect(factory.selectStrategy().mode).toBe("swap");
+  });
+
+  test("throws on an unknown mode (typo defense)", () => {
+    const factory = loadFreshFactory();
+    expect(() => factory.selectStrategy("manaul")).toThrow(/Unknown TREASURY_CONVERSION_MODE/i);
+  });
+
+  test("MODES export is a frozen lookup", () => {
+    const factory = loadFreshFactory();
+    expect(factory.MODES).toEqual({ MANUAL: "manual", SWAP: "swap", BURN_REDEEM: "burn_redeem" });
+    expect(Object.isFrozen(factory.MODES)).toBe(true);
+  });
+
+  test("__REGISTRY contains every advertised mode", () => {
+    const factory = loadFreshFactory();
+    expect(Object.keys(factory.__REGISTRY).sort()).toEqual(
+      ["burn_redeem", "manual", "swap"].sort(),
+    );
+    // Each entry is shape-conformant.
+    for (const strategy of Object.values(factory.__REGISTRY)) {
+      expect(typeof strategy.convert).toBe("function");
+    }
+  });
+});

--- a/backend/harjoot/strategies/burnRedeemConversion.js
+++ b/backend/harjoot/strategies/burnRedeemConversion.js
@@ -1,0 +1,15 @@
+// backend/harjoot/strategies/burnRedeemConversion.js
+//
+// STUB. DS TODO 3: HACK is burned and redeemed for USDT against a
+// treasury contract. Blockchain dev owns the implementation; the
+// factory selects this when TREASURY_CONVERSION_MODE is "burn_redeem".
+
+const NOT_IMPLEMENTED =
+  "burnRedeemConversion is not implemented yet — DS TODO 3 (blockchain dev). " +
+  "Keep TREASURY_CONVERSION_MODE=manual until this lands.";
+
+async function convert(_params) {
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+module.exports = { convert };

--- a/backend/harjoot/strategies/dexSwapConversion.js
+++ b/backend/harjoot/strategies/dexSwapConversion.js
@@ -1,0 +1,21 @@
+// backend/harjoot/strategies/dexSwapConversion.js
+//
+// STUB. DS TODO 3: HACK -> USDT via an on-chain DEX (Uniswap V3 router
+// or QuickSwap on Polygon). Blockchain dev owns the implementation;
+// this file exists so the factory can select the strategy at startup
+// and the worker fails loudly when somebody flips the mode without
+// implementing the swap.
+//
+// Selected when TREASURY_CONVERSION_MODE is "swap".
+
+const NOT_IMPLEMENTED =
+  "dexSwapConversion is not implemented yet — DS TODO 3 (blockchain dev). " +
+  "Keep TREASURY_CONVERSION_MODE=manual until this lands.";
+
+async function convert(_params) {
+  // Intentional throw — silently returning anything here would let the
+  // worker think the batch was settled and mark rows as sent.
+  throw new Error(NOT_IMPLEMENTED);
+}
+
+module.exports = { convert };

--- a/backend/harjoot/strategies/factory.js
+++ b/backend/harjoot/strategies/factory.js
@@ -1,0 +1,53 @@
+// backend/harjoot/strategies/factory.js
+//
+// Selects the conversion strategy at startup based on
+// TREASURY_CONVERSION_MODE. Validates that the chosen module honors
+// the IConversionStrategy contract.
+//
+// Modes:
+//   "manual"      -> manualConversion       (default, launch)
+//   "swap"        -> dexSwapConversion      (stub, DS TODO 3)
+//   "burn_redeem" -> burnRedeemConversion   (stub, DS TODO 3)
+
+const { assertIsConversionStrategy } = require("./IConversionStrategy");
+const manualConversion      = require("./manualConversion");
+const dexSwapConversion     = require("./dexSwapConversion");
+const burnRedeemConversion  = require("./burnRedeemConversion");
+
+const MODE_MANUAL       = "manual";
+const MODE_SWAP         = "swap";
+const MODE_BURN_REDEEM  = "burn_redeem";
+
+const REGISTRY = Object.freeze({
+  [MODE_MANUAL]:      manualConversion,
+  [MODE_SWAP]:        dexSwapConversion,
+  [MODE_BURN_REDEEM]: burnRedeemConversion,
+});
+
+// Shape-check every registered strategy at module load so a missing
+// `convert` function is caught at boot, not at the first treasury cron tick.
+for (const [name, strategy] of Object.entries(REGISTRY)) {
+  assertIsConversionStrategy(name, strategy);
+}
+
+/**
+ * @param {string} [mode] Override env (mostly for tests).
+ * @returns {{ mode: string, strategy: { convert: Function } }}
+ */
+function selectStrategy(mode) {
+  const chosen = mode || process.env.TREASURY_CONVERSION_MODE || MODE_MANUAL;
+  if (!Object.prototype.hasOwnProperty.call(REGISTRY, chosen)) {
+    throw new Error(
+      `Unknown TREASURY_CONVERSION_MODE=${chosen}. ` +
+        `Allowed: ${Object.keys(REGISTRY).join(", ")}`,
+    );
+  }
+  return { mode: chosen, strategy: REGISTRY[chosen] };
+}
+
+module.exports = {
+  selectStrategy,
+  // Exposed for tests asserting on the registry.
+  __REGISTRY: REGISTRY,
+  MODES: Object.freeze({ MANUAL: MODE_MANUAL, SWAP: MODE_SWAP, BURN_REDEEM: MODE_BURN_REDEEM }),
+};

--- a/backend/harjoot/strategies/manualConversion.js
+++ b/backend/harjoot/strategies/manualConversion.js
@@ -1,0 +1,27 @@
+// backend/harjoot/strategies/manualConversion.js
+//
+// Launch-time strategy. Does NOT touch the chain — it parks the batch
+// so a human operator can perform the HACK -> USDT swap and the USDT
+// transfer to Harjoot out of band, then mark the rows as `sent`.
+//
+// Selected when TREASURY_CONVERSION_MODE is "manual" (the default).
+
+const LOG_PREFIX = "[manualConversion]";
+
+/**
+ * @param {{ hackAmount: bigint }} params
+ * @returns {Promise<{ mode: "manual", awaitingManual: true }>}
+ */
+async function convert({ hackAmount }) {
+  if (typeof hackAmount !== "bigint" || hackAmount <= 0n) {
+    throw new TypeError("manualConversion.convert requires a positive bigint hackAmount");
+  }
+  console.log(
+    `${LOG_PREFIX} batch parked for manual conversion hack_total=${hackAmount}`,
+  );
+  // Worker uses awaitingManual=true to short-circuit the on-chain steps
+  // and transition the queued rows to status="awaiting_manual_conversion".
+  return { mode: "manual", awaitingManual: true };
+}
+
+module.exports = { convert };

--- a/backend/harjoot/usecases/__tests__/activateMembership.test.js
+++ b/backend/harjoot/usecases/__tests__/activateMembership.test.js
@@ -1,0 +1,168 @@
+// backend/harjoot/usecases/__tests__/activateMembership.test.js
+//
+// Unit tests for the Section 2 membership activation hook. The mock client
+// drives the Harjoot side; a stub `models.User` captures the persistence side
+// so we can assert exactly what was written without spinning up a database.
+
+const { activateMembership } = require("../activateMembership");
+const { createMockClient } = require("../../client/mockClient");
+const { HarjootUnavailableError, HarjootAuthError } = require("../../client/errors");
+
+function makeUserModelStub() {
+  return {
+    update: jest.fn().mockResolvedValue([1]),
+  };
+}
+
+function makeUser(overrides = {}) {
+  return {
+    id: 42,
+    wallet_address: "0xabc",
+    role: "issuer",
+    name: "Edu",
+    lastname: "Cator",
+    email: "edu@example.com",
+    ...overrides,
+  };
+}
+
+describe("activateMembership", () => {
+  let client;
+  let User;
+  let models;
+
+  beforeAll(() => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    client = createMockClient();
+    User = makeUserModelStub();
+    models = { User };
+  });
+
+  // ---------------------------------------------------------------------------
+  // Happy path
+  // ---------------------------------------------------------------------------
+
+  test("on success, returns ok=true with the membership expiry", async () => {
+    const user = makeUser({ role: "student" });
+    const result = await activateMembership({
+      client,
+      models,
+      role: "student",
+      user,
+      profile: { field_of_study: "Cybersecurity" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeNull();
+    expect(typeof result.expiresAt).toBe("string");
+    expect(new Date(result.expiresAt).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  test("on success, persists harjoot_membership_expires_at on the user row", async () => {
+    const user = makeUser({ id: 17, role: "recruiter" });
+    await activateMembership({
+      client,
+      models,
+      role: "recruiter",
+      user,
+      profile: { company_name: "Acme" },
+    });
+
+    expect(User.update).toHaveBeenCalledTimes(1);
+    const [update, opts] = User.update.mock.calls[0];
+    expect(update.harjoot_membership_expires_at).toBeDefined();
+    expect(opts.where).toEqual({ id: 17 });
+  });
+
+  test("forwards the HackChain role to client.activateAccess as-is (mapping is the client's job)", async () => {
+    const spy = jest.spyOn(client, "activateAccess");
+    const user = makeUser({ role: "issuer" });
+    await activateMembership({
+      client,
+      models,
+      role: "issuer",
+      user,
+      profile: { organization_name: "Cyber Academy" },
+    });
+
+    expect(spy).toHaveBeenCalledWith("issuer", user, { organization_name: "Cyber Academy" });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Failure paths — must NEVER throw
+  // ---------------------------------------------------------------------------
+
+  test("when Harjoot is unavailable, returns ok=false and does NOT throw", async () => {
+    client.__setNextError("activateAccess", new HarjootUnavailableError());
+    const user = makeUser();
+
+    // This is the whole point: registration must keep going even if Harjoot is down.
+    const result = await activateMembership({
+      client,
+      models,
+      role: "issuer",
+      user,
+      profile: { organization_name: "X" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeInstanceOf(HarjootUnavailableError);
+    expect(result.expiresAt).toBeNull();
+  });
+
+  test("when Harjoot returns auth error, does NOT throw and does NOT persist", async () => {
+    client.__setNextError("activateAccess", new HarjootAuthError());
+    const user = makeUser();
+
+    const result = await activateMembership({
+      client,
+      models,
+      role: "issuer",
+      user,
+      profile: { organization_name: "X" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeInstanceOf(HarjootAuthError);
+    expect(User.update).not.toHaveBeenCalled();
+  });
+
+  test("when activateAccess succeeds but response has no expires_at, skips persistence and still returns ok", async () => {
+    client.__setNextResponse("activateAccess", { success: true, membership: { active: true } });
+    const user = makeUser();
+
+    const result = await activateMembership({
+      client,
+      models,
+      role: "student",
+      user,
+      profile: {},
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.expiresAt).toBeNull();
+    expect(User.update).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Invariants
+  // ---------------------------------------------------------------------------
+
+  test("throws TypeError when required deps are missing (caller bug, NOT upstream)", async () => {
+    await expect(
+      activateMembership({ client, role: "student", user: makeUser(), profile: {} }),
+    ).rejects.toThrow(TypeError);
+
+    await expect(
+      activateMembership({ models, role: "student", user: makeUser(), profile: {} }),
+    ).rejects.toThrow(TypeError);
+  });
+});

--- a/backend/harjoot/usecases/__tests__/checkPartnerHealth.test.js
+++ b/backend/harjoot/usecases/__tests__/checkPartnerHealth.test.js
@@ -1,0 +1,139 @@
+// backend/harjoot/usecases/__tests__/checkPartnerHealth.test.js
+//
+// Unit tests for the Section 0 partner health check. The mock client provides
+// a controllable Harjoot stub so we can exercise success, failure, and the
+// "last-known-good" cache behaviour without any network.
+
+const {
+  checkPartnerHealth,
+  getCachedPartnerInfo,
+  getHealthState,
+  __resetForTests,
+} = require("../checkPartnerHealth");
+const { createMockClient } = require("../../client/mockClient");
+const { HarjootUnavailableError } = require("../../client/errors");
+
+describe("checkPartnerHealth", () => {
+  let client;
+
+  beforeAll(() => {
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    __resetForTests();
+    client = createMockClient();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Success path
+  // ---------------------------------------------------------------------------
+
+  test("on success returns ok=true with the partner info from the client", async () => {
+    const result = await checkPartnerHealth(client);
+
+    expect(result.ok).toBe(true);
+    expect(result.error).toBeNull();
+    expect(result.info.partner.slug).toBe("hackchain");
+    expect(result.info.partner.active).toBe(true);
+    expect(result.info.modes).toEqual(expect.arrayContaining(["hash_only"]));
+  });
+
+  test("on success updates the in-memory cache", async () => {
+    expect(getCachedPartnerInfo()).toBeNull();
+    await checkPartnerHealth(client);
+    expect(getCachedPartnerInfo()).not.toBeNull();
+    expect(getCachedPartnerInfo().partner.slug).toBe("hackchain");
+  });
+
+  test("on success updates lastCheckedAt and clears any previous lastError", async () => {
+    // Seed a previous failure
+    client.__setNextError("getPartnerInfo", new HarjootUnavailableError());
+    await checkPartnerHealth(client);
+    expect(getHealthState().lastError).not.toBeNull();
+
+    // A successful check clears it
+    await checkPartnerHealth(client);
+    const state = getHealthState();
+    expect(state.hasCache).toBe(true);
+    expect(state.lastError).toBeNull();
+    expect(state.lastCheckedAt).toBeInstanceOf(Date);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Failure path
+  // ---------------------------------------------------------------------------
+
+  test("on failure returns ok=false and DOES NOT throw", async () => {
+    client.__setNextError("getPartnerInfo", new HarjootUnavailableError());
+
+    // The whole point: even an upstream outage must not crash the startup path.
+    const result = await checkPartnerHealth(client);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeInstanceOf(HarjootUnavailableError);
+  });
+
+  test("on failure when no previous cache existed, getCachedPartnerInfo stays null", async () => {
+    client.__setNextError("getPartnerInfo", new HarjootUnavailableError());
+    await checkPartnerHealth(client);
+    expect(getCachedPartnerInfo()).toBeNull();
+  });
+
+  test("on failure records the error in lastError", async () => {
+    const upstream = new HarjootUnavailableError();
+    client.__setNextError("getPartnerInfo", upstream);
+
+    await checkPartnerHealth(client);
+
+    const state = getHealthState();
+    expect(state.lastError).toMatchObject({
+      name: "HarjootUnavailableError",
+      message: expect.stringMatching(/Harjoot/),
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Last-known-good cache behaviour
+  // ---------------------------------------------------------------------------
+
+  test("a failure AFTER a previous success keeps the last-known-good cache", async () => {
+    // First call succeeds and populates the cache
+    const firstResult = await checkPartnerHealth(client);
+    expect(firstResult.ok).toBe(true);
+    const firstCache = getCachedPartnerInfo();
+    expect(firstCache).not.toBeNull();
+
+    // Second call fails — but the cache stays
+    client.__setNextError("getPartnerInfo", new HarjootUnavailableError());
+    const secondResult = await checkPartnerHealth(client);
+
+    expect(secondResult.ok).toBe(false);
+    // result.info exposes the last-known-good for callers that care
+    expect(secondResult.info).toEqual(firstCache);
+    // and the module cache is unchanged
+    expect(getCachedPartnerInfo()).toEqual(firstCache);
+  });
+
+  // ---------------------------------------------------------------------------
+  // getHealthState
+  // ---------------------------------------------------------------------------
+
+  test("getHealthState reports hasCache=false before any check runs", () => {
+    const state = getHealthState();
+    expect(state).toEqual({ hasCache: false, lastCheckedAt: null, lastError: null });
+  });
+
+  test("getHealthState reflects the current cache after a successful check", async () => {
+    await checkPartnerHealth(client);
+    const state = getHealthState();
+    expect(state.hasCache).toBe(true);
+    expect(state.lastCheckedAt).toBeInstanceOf(Date);
+    expect(state.lastError).toBeNull();
+  });
+});

--- a/backend/harjoot/usecases/__tests__/educatorApproval.test.js
+++ b/backend/harjoot/usecases/__tests__/educatorApproval.test.js
@@ -1,0 +1,254 @@
+// backend/harjoot/usecases/__tests__/educatorApproval.test.js
+//
+// Unit tests for the Section 2.5 approve/reject use cases. SQLite in-memory
+// for the real Sequelize update path; a jest-mocked emailService captures the
+// side-effect calls without sending anything.
+
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+
+const { approveEducator } = require("../approveEducator");
+const { rejectEducator } = require("../rejectEducator");
+
+jest.setTimeout(10000);
+
+describe("Educator approval use cases", () => {
+  let sequelize;
+  let User, Student, Issuer, Recruiter, UserSession, Certificate;
+  let models;
+  let emailService;
+
+  const ISSUER_WALLET = "0x1111111111111111111111111111111111111111";
+  const STUDENT_WALLET = "0x2222222222222222222222222222222222222222";
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    const { DataTypes } = SequelizePkg;
+
+    User = require("../../../models/users")(sequelize, DataTypes);
+    Student = require("../../../models/students")(sequelize, DataTypes);
+    Student.rawAttributes.wallet_address.unique = true;
+    Issuer = require("../../../models/issuers")(sequelize, DataTypes);
+    Recruiter = require("../../../models/recruiters")(sequelize, DataTypes);
+    UserSession = require("../../../models/userSessions")(sequelize, DataTypes);
+    Certificate = require("../../../models/certificates")(sequelize, DataTypes);
+
+    const allModels = { User, Student, Issuer, Recruiter, UserSession, Certificate };
+    Object.values(allModels).forEach((m) => m.associate && m.associate(allModels));
+
+    await sequelize.sync({ force: true });
+    models = allModels;
+
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    if (sequelize) await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+    emailService = {
+      notifyEducatorApproved: jest.fn().mockResolvedValue(undefined),
+      notifyEducatorRejected: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  async function makeIssuer({ id, email = "edu@example.com", status = "pending_approval", rejection_reason = null }) {
+    const user = await User.create({
+      id,
+      wallet_address: ISSUER_WALLET,
+      role: "issuer",
+      name: "Edu",
+      lastname: "Cator",
+      email,
+      nonce: crypto.randomBytes(16).toString("hex"),
+      educator_approval_status: status,
+      rejection_reason,
+    });
+    await Issuer.create({ wallet_address: ISSUER_WALLET, organization_name: "Cyber Academy" });
+    return user;
+  }
+
+  async function makeStudent({ id }) {
+    const user = await User.create({
+      id,
+      wallet_address: STUDENT_WALLET,
+      role: "student",
+      name: "Sty",
+      email: "s@example.com",
+      nonce: crypto.randomBytes(16).toString("hex"),
+    });
+    await Student.create({ wallet_address: STUDENT_WALLET });
+    return user;
+  }
+
+  // ===========================================================================
+  // approveEducator
+  // ===========================================================================
+
+  describe("approveEducator", () => {
+    test("on success updates educator_approval_status='approved' + approved_at + approved_by", async () => {
+      const user = await makeIssuer({ id: 100 });
+      const result = await approveEducator({ models, emailService, userId: 100, adminId: 1 });
+
+      expect(result.ok).toBe(true);
+      expect(result.user).toMatchObject({ id: 100, status: "approved" });
+
+      const reloaded = await User.findByPk(100);
+      expect(reloaded.educator_approval_status).toBe("approved");
+      expect(reloaded.approved_at).toBeInstanceOf(Date);
+      expect(reloaded.approved_by).toBe(1);
+    });
+
+    test("on success clears any previous rejection_reason", async () => {
+      await makeIssuer({ id: 101, status: "rejected", rejection_reason: "old reason" });
+
+      await approveEducator({ models, emailService, userId: 101, adminId: 1 });
+
+      const reloaded = await User.findByPk(101);
+      expect(reloaded.rejection_reason).toBeNull();
+    });
+
+    test("triggers emailService.notifyEducatorApproved with the user's email and name", async () => {
+      await makeIssuer({ id: 102, email: "to@example.com" });
+
+      await approveEducator({ models, emailService, userId: 102, adminId: 1 });
+
+      expect(emailService.notifyEducatorApproved).toHaveBeenCalledTimes(1);
+      expect(emailService.notifyEducatorApproved).toHaveBeenCalledWith({
+        to: "to@example.com",
+        name: "Edu",
+      });
+    });
+
+    test("DOES NOT undo the DB update when the email throws", async () => {
+      await makeIssuer({ id: 103 });
+      emailService.notifyEducatorApproved.mockRejectedValue(new Error("Resend down"));
+
+      const result = await approveEducator({ models, emailService, userId: 103, adminId: 1 });
+
+      expect(result.ok).toBe(true); // approval succeeded despite email failure
+      const reloaded = await User.findByPk(103);
+      expect(reloaded.educator_approval_status).toBe("approved");
+    });
+
+    test("rejects USER_NOT_FOUND when the id does not exist", async () => {
+      const result = await approveEducator({ models, emailService, userId: 9999, adminId: 1 });
+      expect(result).toEqual({ ok: false, reason: "USER_NOT_FOUND" });
+      expect(emailService.notifyEducatorApproved).not.toHaveBeenCalled();
+    });
+
+    test("rejects NOT_AN_ISSUER when the user is a student", async () => {
+      await makeStudent({ id: 104 });
+      const result = await approveEducator({ models, emailService, userId: 104, adminId: 1 });
+      expect(result).toEqual({ ok: false, reason: "NOT_AN_ISSUER" });
+    });
+
+    test("rejects ALREADY_APPROVED when status is already 'approved'", async () => {
+      await makeIssuer({ id: 105, status: "approved" });
+      const result = await approveEducator({ models, emailService, userId: 105, adminId: 1 });
+      expect(result).toEqual({ ok: false, reason: "ALREADY_APPROVED" });
+    });
+
+    test("throws TypeError on missing dependencies (programmer bug)", async () => {
+      await expect(approveEducator({ emailService, userId: 1, adminId: 1 })).rejects.toThrow(TypeError);
+      await expect(approveEducator({ models, userId: 1, adminId: 1 })).rejects.toThrow(TypeError);
+    });
+  });
+
+  // ===========================================================================
+  // rejectEducator
+  // ===========================================================================
+
+  describe("rejectEducator", () => {
+    test("on success sets status='rejected' + rejection_reason (trimmed)", async () => {
+      await makeIssuer({ id: 200 });
+      const result = await rejectEducator({
+        models,
+        emailService,
+        userId: 200,
+        adminId: 1,
+        reason: "   KYC docs incomplete   ",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.user).toMatchObject({ id: 200, status: "rejected", rejection_reason: "KYC docs incomplete" });
+
+      const reloaded = await User.findByPk(200);
+      expect(reloaded.educator_approval_status).toBe("rejected");
+      expect(reloaded.rejection_reason).toBe("KYC docs incomplete");
+    });
+
+    test("triggers emailService.notifyEducatorRejected with to + name + reason", async () => {
+      await makeIssuer({ id: 201, email: "x@example.com" });
+
+      await rejectEducator({ models, emailService, userId: 201, adminId: 1, reason: "Bad docs" });
+
+      expect(emailService.notifyEducatorRejected).toHaveBeenCalledTimes(1);
+      expect(emailService.notifyEducatorRejected).toHaveBeenCalledWith({
+        to: "x@example.com",
+        name: "Edu",
+        reason: "Bad docs",
+      });
+    });
+
+    test("clears any previous approved_at / approved_by so the row is consistent", async () => {
+      await makeIssuer({ id: 202 });
+      // Pretend they were previously approved
+      await User.update(
+        { educator_approval_status: "approved", approved_at: new Date(), approved_by: 999 },
+        { where: { id: 202 } },
+      );
+
+      await rejectEducator({ models, emailService, userId: 202, adminId: 1, reason: "Misconduct" });
+
+      const reloaded = await User.findByPk(202);
+      expect(reloaded.educator_approval_status).toBe("rejected");
+      expect(reloaded.approved_at).toBeNull();
+      expect(reloaded.approved_by).toBeNull();
+    });
+
+    test("rejects USER_NOT_FOUND when the id does not exist", async () => {
+      const result = await rejectEducator({
+        models,
+        emailService,
+        userId: 9999,
+        adminId: 1,
+        reason: "Some reason",
+      });
+      expect(result).toEqual({ ok: false, reason: "USER_NOT_FOUND" });
+      expect(emailService.notifyEducatorRejected).not.toHaveBeenCalled();
+    });
+
+    test("rejects NOT_AN_ISSUER when the user is not an issuer", async () => {
+      await makeStudent({ id: 203 });
+      const result = await rejectEducator({
+        models,
+        emailService,
+        userId: 203,
+        adminId: 1,
+        reason: "Not eligible",
+      });
+      expect(result).toEqual({ ok: false, reason: "NOT_AN_ISSUER" });
+    });
+
+    test("throws TypeError when reason is missing or blank", async () => {
+      await expect(
+        rejectEducator({ models, emailService, userId: 1, adminId: 1 }),
+      ).rejects.toThrow(TypeError);
+      await expect(
+        rejectEducator({ models, emailService, userId: 1, adminId: 1, reason: "   " }),
+      ).rejects.toThrow(TypeError);
+      await expect(
+        rejectEducator({ models, emailService, userId: 1, adminId: 1, reason: 123 }),
+      ).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/backend/harjoot/usecases/__tests__/ensureMembership.test.js
+++ b/backend/harjoot/usecases/__tests__/ensureMembership.test.js
@@ -1,0 +1,228 @@
+// backend/harjoot/usecases/__tests__/ensureMembership.test.js
+//
+// Unit tests for the Section 3 membership guard. Uses an in-memory SQLite to
+// exercise real Sequelize queries (User + role profiles) and the mock client
+// to drive every Harjoot response/error scenario.
+
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+
+const { ensureMembership } = require("../ensureMembership");
+const { createMockClient } = require("../../client/mockClient");
+const { HarjootUnavailableError } = require("../../client/errors");
+
+jest.setTimeout(10000);
+
+describe("ensureMembership", () => {
+  let sequelize;
+  let User, Student, Issuer, Recruiter, UserSession, Certificate;
+  let models;
+
+  const ISSUER_WALLET = "0x1111111111111111111111111111111111111111";
+  const STUDENT_WALLET = "0x2222222222222222222222222222222222222222";
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    const { DataTypes } = SequelizePkg;
+
+    User = require("../../../models/users")(sequelize, DataTypes);
+    Student = require("../../../models/students")(sequelize, DataTypes);
+    // SQLite FK requires UNIQUE on referenced column — Student.wallet_address
+    // is not unique in the production model. Patching the in-memory attribute
+    // keeps the file untouched. Same workaround as harjootModels.test.js.
+    Student.rawAttributes.wallet_address.unique = true;
+    Issuer = require("../../../models/issuers")(sequelize, DataTypes);
+    Recruiter = require("../../../models/recruiters")(sequelize, DataTypes);
+    UserSession = require("../../../models/userSessions")(sequelize, DataTypes);
+    Certificate = require("../../../models/certificates")(sequelize, DataTypes);
+
+    const allModels = { User, Student, Issuer, Recruiter, UserSession, Certificate };
+    Object.values(allModels).forEach((m) => m.associate && m.associate(allModels));
+
+    await sequelize.sync({ force: true });
+    models = allModels;
+
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    if (sequelize) await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  async function makeStudent({ id, expiresAt }) {
+    const user = await User.create({
+      id,
+      wallet_address: STUDENT_WALLET,
+      role: "student",
+      name: "Sty",
+      nonce: crypto.randomBytes(16).toString("hex"),
+      harjoot_membership_expires_at: expiresAt || null,
+    });
+    await Student.create({ wallet_address: STUDENT_WALLET, field_of_study: "Cybersecurity" });
+    return user;
+  }
+
+  async function makeIssuer({ id, expiresAt }) {
+    const user = await User.create({
+      id,
+      wallet_address: ISSUER_WALLET,
+      role: "issuer",
+      name: "Edu",
+      nonce: crypto.randomBytes(16).toString("hex"),
+      harjoot_membership_expires_at: expiresAt || null,
+      educator_approval_status: "pending_approval",
+    });
+    await Issuer.create({ wallet_address: ISSUER_WALLET, organization_name: "Cyber Academy" });
+    return user;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Hot path — cached locally
+  // ---------------------------------------------------------------------------
+
+  describe("local cache (expires_at in the future)", () => {
+    test("returns ok with source='cache' and does NOT call Harjoot", async () => {
+      const future = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      const user = await makeStudent({ id: 101, expiresAt: future });
+
+      const client = createMockClient();
+      const result = await ensureMembership({ client, models, userId: user.id });
+
+      expect(result.ok).toBe(true);
+      expect(result.source).toBe("cache");
+      expect(new Date(result.expiresAt).getTime()).toBe(future.getTime());
+      expect(client.__calls).toHaveLength(0);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cold path — checkAccess returns active
+  // ---------------------------------------------------------------------------
+
+  describe("expired cache + Harjoot reports active", () => {
+    test("calls checkAccess only, persists the new expiry, returns source='check'", async () => {
+      const past = new Date(Date.now() - 60_000);
+      const user = await makeStudent({ id: 201, expiresAt: past });
+
+      const client = createMockClient();
+      const result = await ensureMembership({ client, models, userId: user.id });
+
+      expect(result.ok).toBe(true);
+      expect(result.source).toBe("check");
+      expect(client.__calls.map((c) => c.method)).toEqual(["checkAccess"]);
+
+      const reloaded = await User.findByPk(user.id);
+      expect(new Date(reloaded.harjoot_membership_expires_at).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    test("works when the user has no prior expiry at all (null)", async () => {
+      const user = await makeStudent({ id: 202, expiresAt: null });
+
+      const client = createMockClient();
+      const result = await ensureMembership({ client, models, userId: user.id });
+
+      expect(result.ok).toBe(true);
+      expect(result.source).toBe("check");
+      expect(client.__calls.map((c) => c.method)).toEqual(["checkAccess"]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cold path — checkAccess inactive → reactivate
+  // ---------------------------------------------------------------------------
+
+  describe("expired cache + Harjoot reports inactive", () => {
+    test("calls checkAccess THEN activateAccess and returns source='reactivated'", async () => {
+      const user = await makeIssuer({ id: 301, expiresAt: null });
+      const client = createMockClient();
+      client.__setNextResponse("checkAccess", { active: false, expires_at: null });
+
+      const result = await ensureMembership({ client, models, userId: user.id });
+
+      expect(result.ok).toBe(true);
+      expect(result.source).toBe("reactivated");
+      expect(client.__calls.map((c) => c.method)).toEqual(["checkAccess", "activateAccess"]);
+
+      const reloaded = await User.findByPk(user.id);
+      expect(new Date(reloaded.harjoot_membership_expires_at).getTime()).toBeGreaterThan(Date.now());
+    });
+
+    test("passes the role and the role-specific profile to activateAccess", async () => {
+      const user = await makeIssuer({ id: 302, expiresAt: null });
+      const client = createMockClient();
+      client.__setNextResponse("checkAccess", { active: false, expires_at: null });
+
+      await ensureMembership({ client, models, userId: user.id });
+
+      const activateCall = client.__calls.find((c) => c.method === "activateAccess");
+      expect(activateCall).toBeDefined();
+      const [role, calledUser, profile] = activateCall.args;
+      expect(role).toBe("issuer");
+      expect(calledUser.id).toBe(user.id);
+      expect(profile.organization_name).toBe("Cyber Academy");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Soft-fail when Harjoot is unreachable
+  // ---------------------------------------------------------------------------
+
+  describe("Harjoot is unreachable", () => {
+    test("returns ok=true with soft_failed=true and DOES NOT throw", async () => {
+      const user = await makeStudent({ id: 401, expiresAt: null });
+      const client = createMockClient();
+      client.__setNextError("checkAccess", new HarjootUnavailableError());
+
+      // The whole point: membership errors must never block a logged-in user.
+      const result = await ensureMembership({ client, models, userId: user.id });
+
+      expect(result.ok).toBe(true);
+      expect(result.soft_failed).toBe(true);
+      expect(result.error).toBeInstanceOf(HarjootUnavailableError);
+    });
+
+    test("preserves the previous expires_at on the user row (no destructive update)", async () => {
+      const oldExpiry = new Date(Date.now() - 60_000); // a known stale value
+      const user = await makeStudent({ id: 402, expiresAt: oldExpiry });
+      const client = createMockClient();
+      client.__setNextError("checkAccess", new HarjootUnavailableError());
+
+      await ensureMembership({ client, models, userId: user.id });
+
+      const reloaded = await User.findByPk(user.id);
+      // We did not write anything new; the column is whatever it was before.
+      expect(new Date(reloaded.harjoot_membership_expires_at).getTime()).toBe(oldExpiry.getTime());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge cases
+  // ---------------------------------------------------------------------------
+
+  describe("edge cases", () => {
+    test("returns ok=false with reason USER_NOT_FOUND when the user id does not exist", async () => {
+      const client = createMockClient();
+      const result = await ensureMembership({ client, models, userId: 99999 });
+
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe("USER_NOT_FOUND");
+      expect(client.__calls).toHaveLength(0);
+    });
+
+    test("throws TypeError on missing dependencies (caller bug)", async () => {
+      await expect(ensureMembership({ models, userId: 1 })).rejects.toThrow(TypeError);
+      await expect(ensureMembership({ client: createMockClient(), userId: 1 })).rejects.toThrow(TypeError);
+      await expect(ensureMembership({ client: createMockClient(), models })).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/backend/harjoot/usecases/__tests__/issueCertificate.test.js
+++ b/backend/harjoot/usecases/__tests__/issueCertificate.test.js
@@ -1,0 +1,489 @@
+// backend/harjoot/usecases/__tests__/issueCertificate.test.js
+//
+// All external deps (paymentService, harjootClient, mintAdapter,
+// ipfsUpload, provider) are mocked. SQLite in-memory backs the real
+// Sequelize models so we exercise the transaction boundary AND verify
+// the Certificate + TreasuryTransfer rows actually persisted.
+
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+
+const { issueCertificate } = require("../issueCertificate");
+
+const EDUCATOR_WALLET = "0x1111111111111111111111111111111111111111";
+const STUDENT_WALLET  = "0x2222222222222222222222222222222222222222";
+const PAYMENT_TX      = "0x" + "ab".repeat(32);
+const PDF_BUFFER      = Buffer.from("fake-pdf-bytes");
+
+// Pre-computed SHA-256 of PDF_BUFFER so we can assert on it without
+// re-running the hash in the test body.
+const EXPECTED_HASH = crypto.createHash("sha256").update(PDF_BUFFER).digest("hex");
+
+const DEFAULT_PRICING = {
+  amountHack: 6900n,
+  userPriceUsdCents: 69,
+  harjootCostUsdCents: 20,
+  grossMarginUsdCents: 49,
+  treasuryAddress: "0x0000000000000000000000000000000000000bee",
+  hackTokenAddress: "0x0000000000000000000000000000000000000ace",
+};
+
+const HARJOOT_OK_RESPONSE = {
+  success: true,
+  certificate: {
+    verificationId: "ver_mock_xyz",
+    partnerCertificateId: "PC-001",
+    status: "verified",
+    document: { hash: EXPECTED_HASH },
+    verification: {
+      url: "https://harjoot.mock/verify/ver_mock_xyz",
+      qrCodeUrl: "https://harjoot.mock/verify/ver_mock_xyz/qr",
+    },
+    blockchain: { partnerTxHash: null, harjootTxHash: null, explorerUrl: null },
+  },
+};
+
+const MINT_OK_RESULT = { tokenId: 42n, txHash: "0x" + "cd".repeat(32) };
+
+describe("issueCertificate orchestrator", () => {
+  let sequelize;
+  let models;
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    const { DataTypes } = SequelizePkg;
+
+    const User = require("../../../models/users")(sequelize, DataTypes);
+    const Student = require("../../../models/students")(sequelize, DataTypes);
+    Student.rawAttributes.wallet_address.unique = true;
+    const Issuer = require("../../../models/issuers")(sequelize, DataTypes);
+    const Recruiter = require("../../../models/recruiters")(sequelize, DataTypes);
+    const UserSession = require("../../../models/userSessions")(sequelize, DataTypes);
+    const Certificate = require("../../../models/certificates")(sequelize, DataTypes);
+    const Payment = require("../../../models/payments")(sequelize, DataTypes);
+    const TreasuryTransfer = require("../../../models/treasuryTransfers")(sequelize, DataTypes);
+    const TalentInvitation = require("../../../models/talentInvitations")(sequelize, DataTypes);
+
+    const allModels = {
+      User, Student, Issuer, Recruiter, UserSession, Certificate, Payment,
+      TreasuryTransfer, TalentInvitation,
+    };
+    Object.values(allModels).forEach((m) => m.associate && m.associate(allModels));
+
+    await sequelize.sync({ force: true });
+    models = { ...allModels, sequelize };
+
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    if (sequelize) await sequelize.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  async function seedScenario({
+    educatorApprovalStatus = "approved",
+    seedStudent = true,
+    seedIssuer = true,
+  } = {}) {
+    await sequelize.sync({ force: true });
+
+    const educator = await models.User.create({
+      id: 1,
+      wallet_address: EDUCATOR_WALLET,
+      role: "issuer",
+      name: "Sofia",
+      email: "edu@x.com",
+      nonce: crypto.randomBytes(16).toString("hex"),
+      educator_approval_status: educatorApprovalStatus,
+    });
+    if (seedIssuer) {
+      await models.Issuer.create({
+        wallet_address: EDUCATOR_WALLET,
+        organization_name: "Acme Academy",
+      });
+    }
+    if (seedStudent) {
+      await models.User.create({
+        id: 2,
+        wallet_address: STUDENT_WALLET,
+        role: "student",
+        name: "Sty",
+        email: "sty@x.com",
+        nonce: crypto.randomBytes(16).toString("hex"),
+      });
+      await models.Student.create({
+        wallet_address: STUDENT_WALLET,
+        field_of_study: "cyber",
+      });
+    }
+    return educator;
+  }
+
+  function makeDeps({
+    verifyResult,
+    uploadCertResult = HARJOOT_OK_RESPONSE,
+    uploadCertThrows = null,
+    mintResult = MINT_OK_RESULT,
+    mintThrows = null,
+    ipfsResult = { tokenUri: "ipfs://bafy.../meta.json", pdfCid: "bafy-pdf" },
+    ipfsThrows = null,
+  } = {}) {
+    // verifyResult defaults to "this matches our seeded happy-path payment".
+    // Each call simulates the use case creating a Payment row by hand —
+    // we mirror that here since the test mocks paymentService.
+    const defaultVerify = async () => {
+      const row = await models.Payment.create({
+        tx_hash: PAYMENT_TX,
+        from_wallet: EDUCATOR_WALLET,
+        amount_hack: "6900",
+        harjoot_price_usd: "0.2000",
+        user_price_usd: "0.6900",
+        status: "confirmed",
+        purpose: "certificate_issuance",
+      });
+      return {
+        ok: true,
+        payment: { id: row.id, txHash: PAYMENT_TX, fromWallet: EDUCATOR_WALLET, amountHack: 6900n },
+      };
+    };
+
+    const paymentService = {
+      calculateMintPrice: jest.fn().mockReturnValue(DEFAULT_PRICING),
+      verifyHackPayment: jest.fn().mockImplementation(verifyResult || defaultVerify),
+    };
+
+    const harjootClient = {
+      uploadCertificate: jest.fn().mockImplementation(async (payload) => {
+        if (uploadCertThrows) throw uploadCertThrows;
+        return uploadCertResult;
+      }),
+    };
+
+    const mintAdapter = {
+      mintCertificate: jest.fn().mockImplementation(async () => {
+        if (mintThrows) throw mintThrows;
+        return mintResult;
+      }),
+    };
+
+    const ipfsUpload = jest.fn().mockImplementation(async () => {
+      if (ipfsThrows) throw ipfsThrows;
+      return ipfsResult;
+    });
+
+    const provider = { getTransactionReceipt: jest.fn().mockResolvedValue(null) };
+
+    return { paymentService, harjootClient, mintAdapter, ipfsUpload, provider };
+  }
+
+  function buildParams(educator, overrides = {}) {
+    return {
+      models,
+      educator,
+      studentWallet: STUDENT_WALLET,
+      title: "Solidity 101",
+      description: "Smart contracts essentials",
+      issueDate: "2026-06-05",
+      paymentTxHash: PAYMENT_TX,
+      pdfBuffer: PDF_BUFFER,
+      pdfFileName: "cert.pdf",
+      ...overrides,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  test("happy path: persists Certificate + TreasuryTransfer and returns ok envelope", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps();
+
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+
+    expect(result.ok).toBe(true);
+    expect(result.certificate).toMatchObject({
+      tokenId: "42",
+      txHash: MINT_OK_RESULT.txHash,
+      certificateHash: EXPECTED_HASH,
+      tokenUri: "ipfs://bafy.../meta.json",
+      verificationId: "ver_mock_xyz",
+      verificationUrl: "https://harjoot.mock/verify/ver_mock_xyz",
+      qrUrl: "https://harjoot.mock/verify/ver_mock_xyz/qr",
+    });
+
+    // Certificate row
+    const cert = await models.Certificate.findByPk(result.certificate.id);
+    expect(cert.certificate_hash).toBe(EXPECTED_HASH);
+    expect(cert.token_id).toBe("42");
+    expect(cert.blockchain_tx_hash).toBe(MINT_OK_RESULT.txHash);
+    expect(cert.status).toBe("issued");
+    expect(cert.payment_id).toBe(result.certificate.paymentId);
+    expect(cert.harjoot_verification_id).toBe("ver_mock_xyz");
+    expect(cert.issuer_wallet_address).toBe(EDUCATOR_WALLET);
+    expect(cert.student_wallet_address).toBe(STUDENT_WALLET);
+
+    // TreasuryTransfer row
+    const tt = await models.TreasuryTransfer.findByPk(result.certificate.treasuryTransferId);
+    expect(tt.payment_id).toBe(result.certificate.paymentId);
+    expect(Number(tt.amount_usdt_owed)).toBeCloseTo(0.20, 4);
+    expect(tt.status).toBe("pending");
+    expect(tt.destination).toBe("harjoot");
+  });
+
+  test("calls Harjoot uploadCertificate with hash_only mode and a unique idempotency key per call", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps();
+    await issueCertificate({ ...buildParams(educator), ...deps });
+
+    expect(deps.harjootClient.uploadCertificate).toHaveBeenCalledTimes(1);
+    const payload = deps.harjootClient.uploadCertificate.mock.calls[0][0];
+    expect(payload.processing).toEqual({ mode: "hash_only" });
+    expect(payload.document.hash).toBe(EXPECTED_HASH);
+    expect(payload.idempotency_key).toMatch(/^cert-[0-9a-f-]{36}-v1$/);
+    expect(payload.issuer).toEqual({
+      wallet_address: EDUCATOR_WALLET,
+      organization_name: "Acme Academy",
+      email: "edu@x.com",
+    });
+    expect(payload.student).toEqual({ wallet_address: STUDENT_WALLET, name: "Sty" });
+    expect(payload.certificate.token_uri).toBe("ipfs://bafy.../meta.json");
+  });
+
+  test("forwards the computed certificateHash to ipfsUpload + mintAdapter", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps();
+    await issueCertificate({ ...buildParams(educator), ...deps });
+
+    expect(deps.ipfsUpload).toHaveBeenCalledTimes(1);
+    const ipfsArgs = deps.ipfsUpload.mock.calls[0][0];
+    expect(ipfsArgs.certificateHash).toBe(EXPECTED_HASH);
+    expect(ipfsArgs.studentWallet).toBe(STUDENT_WALLET);
+    expect(ipfsArgs.title).toBe("Solidity 101");
+
+    expect(deps.mintAdapter.mintCertificate).toHaveBeenCalledWith({
+      studentWallet: STUDENT_WALLET,
+      studentName: "Sty",
+      courseName: "Solidity 101",
+      tokenUri: "ipfs://bafy.../meta.json",
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Pre-payment gates
+  // -------------------------------------------------------------------------
+
+  test("EDUCATOR_NOT_APPROVED short-circuits before payment is touched", async () => {
+    const educator = await seedScenario({ educatorApprovalStatus: "pending_approval" });
+    const deps = makeDeps();
+
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+
+    expect(result).toEqual({ ok: false, reason: "EDUCATOR_NOT_APPROVED" });
+    expect(deps.paymentService.verifyHackPayment).not.toHaveBeenCalled();
+    expect(deps.ipfsUpload).not.toHaveBeenCalled();
+    expect(await models.Payment.count()).toBe(0);
+    expect(await models.Certificate.count()).toBe(0);
+  });
+
+  test("TALENT_NOT_FOUND short-circuits before payment is touched", async () => {
+    const educator = await seedScenario({ seedStudent: false });
+    const deps = makeDeps();
+
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+
+    expect(result.reason).toBe("TALENT_NOT_FOUND");
+    expect(deps.paymentService.verifyHackPayment).not.toHaveBeenCalled();
+    expect(await models.Payment.count()).toBe(0);
+  });
+
+  test("TALENT_NOT_FOUND when wallet matches but role is recruiter", async () => {
+    const educator = await seedScenario({ seedStudent: false });
+    await models.User.create({
+      id: 99,
+      wallet_address: STUDENT_WALLET,
+      role: "recruiter",
+      name: "Rec",
+      email: "rec@x.com",
+      nonce: crypto.randomBytes(16).toString("hex"),
+    });
+    const deps = makeDeps();
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+    expect(result.reason).toBe("TALENT_NOT_FOUND");
+  });
+
+  // -------------------------------------------------------------------------
+  // Payment failures bubble up
+  // -------------------------------------------------------------------------
+
+  test("bubbles up TX_NOT_FOUND from verifyHackPayment with no side effects", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps({
+      verifyResult: async () => ({ ok: false, reason: "TX_NOT_FOUND" }),
+    });
+
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+    expect(result).toEqual({ ok: false, reason: "TX_NOT_FOUND" });
+    expect(deps.ipfsUpload).not.toHaveBeenCalled();
+    expect(deps.mintAdapter.mintCertificate).not.toHaveBeenCalled();
+  });
+
+  test("bubbles up REPLAY with existingPaymentId attached", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps({
+      verifyResult: async () => ({ ok: false, reason: "REPLAY", existingPaymentId: 77 }),
+    });
+
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+    expect(result.reason).toBe("REPLAY");
+    expect(result.existingPaymentId).toBe(77);
+  });
+
+  test("bubbles up INSUFFICIENT_AMOUNT without minting", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps({
+      verifyResult: async () => ({ ok: false, reason: "INSUFFICIENT_AMOUNT" }),
+    });
+
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+    expect(result.reason).toBe("INSUFFICIENT_AMOUNT");
+    expect(deps.mintAdapter.mintCertificate).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Failures AFTER payment (paymentId carried in the Result)
+  // -------------------------------------------------------------------------
+
+  test("IPFS_FAILED when ipfsUpload throws; payment row already exists; no mint", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps({ ipfsThrows: new Error("pinata down") });
+
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("IPFS_FAILED");
+    expect(result.paymentId).toEqual(expect.any(Number));
+    expect(result.error).toMatch(/pinata down/);
+    expect(await models.Payment.count()).toBe(1); // verifyHackPayment persisted it
+    expect(deps.harjootClient.uploadCertificate).not.toHaveBeenCalled();
+    expect(deps.mintAdapter.mintCertificate).not.toHaveBeenCalled();
+    expect(await models.Certificate.count()).toBe(0);
+    expect(await models.TreasuryTransfer.count()).toBe(0);
+  });
+
+  test("IPFS_FAILED when ipfsUpload returns no tokenUri", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps({ ipfsResult: { pdfCid: "bafy-pdf" } }); // no tokenUri
+
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+    expect(result.reason).toBe("IPFS_FAILED");
+    expect(result.error).toMatch(/tokenUri/);
+  });
+
+  test("HARJOOT_UPLOAD_FAILED when client throws; payment row exists; no mint", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps({ uploadCertThrows: new Error("harjoot 500") });
+
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+    expect(result.reason).toBe("HARJOOT_UPLOAD_FAILED");
+    expect(result.paymentId).toEqual(expect.any(Number));
+    expect(result.error).toMatch(/harjoot 500/);
+    expect(deps.mintAdapter.mintCertificate).not.toHaveBeenCalled();
+    expect(await models.Certificate.count()).toBe(0);
+  });
+
+  test("MINT_FAILED when mintAdapter throws; verificationId is carried in the Result", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps({ mintThrows: new Error("revert") });
+
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+    expect(result.reason).toBe("MINT_FAILED");
+    expect(result.paymentId).toEqual(expect.any(Number));
+    expect(result.verificationId).toBe("ver_mock_xyz");
+    expect(result.error).toMatch(/revert/);
+    expect(await models.Certificate.count()).toBe(0);
+    expect(await models.TreasuryTransfer.count()).toBe(0);
+  });
+
+  test("PERSIST_FAILED carries tokenId + txHash for ops reconciliation", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps();
+
+    // Sabotage the Certificate.create so the persistence transaction explodes
+    // after the mint succeeds.
+    const createSpy = jest
+      .spyOn(models.Certificate, "create")
+      .mockRejectedValueOnce(new Error("disk full"));
+
+    const result = await issueCertificate({ ...buildParams(educator), ...deps });
+
+    createSpy.mockRestore();
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("PERSIST_FAILED");
+    expect(result.tokenId).toBe("42");
+    expect(result.txHash).toBe(MINT_OK_RESULT.txHash);
+    expect(result.certificateHash).toBe(EXPECTED_HASH);
+    expect(result.tokenUri).toBe("ipfs://bafy.../meta.json");
+    expect(result.verificationId).toBe("ver_mock_xyz");
+
+    // No row on either side — transaction rolled back even though mint was off-chain.
+    expect(await models.Certificate.count()).toBe(0);
+    expect(await models.TreasuryTransfer.count()).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Programmer-error guards
+  // -------------------------------------------------------------------------
+
+  test("throws TypeError when models is missing", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps();
+    await expect(
+      issueCertificate({ ...buildParams(educator), ...deps, models: undefined }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError when paymentService is missing", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps();
+    delete deps.paymentService;
+    await expect(
+      issueCertificate({ ...buildParams(educator), ...deps }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError on malformed studentWallet", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps();
+    await expect(
+      issueCertificate({ ...buildParams(educator, { studentWallet: "nope" }), ...deps }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError on malformed issueDate", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps();
+    await expect(
+      issueCertificate({ ...buildParams(educator, { issueDate: "06/05/2026" }), ...deps }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError when pdfBuffer is empty", async () => {
+    const educator = await seedScenario();
+    const deps = makeDeps();
+    await expect(
+      issueCertificate({ ...buildParams(educator, { pdfBuffer: Buffer.alloc(0) }), ...deps }),
+    ).rejects.toThrow(TypeError);
+  });
+});

--- a/backend/harjoot/usecases/__tests__/precheckCertificate.test.js
+++ b/backend/harjoot/usecases/__tests__/precheckCertificate.test.js
@@ -1,0 +1,265 @@
+// backend/harjoot/usecases/__tests__/precheckCertificate.test.js
+//
+// SQLite-in-memory exercises the real Sequelize query. paymentService is
+// mocked so we can verify the pure DI seam, not the pricing math (that has
+// its own tests in services/__tests__/paymentService.test.js).
+
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+
+const { precheckCertificate } = require("../precheckCertificate");
+
+describe("Section 4 precheck use case", () => {
+  let sequelize;
+  let User, Student, Issuer, Recruiter, UserSession, Certificate, TalentInvitation;
+  let models;
+  let paymentService;
+
+  const ISSUER_WALLET = "0x1111111111111111111111111111111111111111";
+  const STUDENT_WALLET = "0x2222222222222222222222222222222222222222";
+  const RECRUITER_WALLET = "0x3333333333333333333333333333333333333333";
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    const { DataTypes } = SequelizePkg;
+
+    User = require("../../../models/users")(sequelize, DataTypes);
+    Student = require("../../../models/students")(sequelize, DataTypes);
+    Student.rawAttributes.wallet_address.unique = true;
+    Issuer = require("../../../models/issuers")(sequelize, DataTypes);
+    Recruiter = require("../../../models/recruiters")(sequelize, DataTypes);
+    UserSession = require("../../../models/userSessions")(sequelize, DataTypes);
+    Certificate = require("../../../models/certificates")(sequelize, DataTypes);
+    TalentInvitation = require("../../../models/talentInvitations")(sequelize, DataTypes);
+
+    const allModels = { User, Student, Issuer, Recruiter, UserSession, Certificate, TalentInvitation };
+    Object.values(allModels).forEach((m) => m.associate && m.associate(allModels));
+
+    await sequelize.sync({ force: true });
+    models = allModels;
+
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    if (sequelize) await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+    paymentService = {
+      calculateMintPrice: jest.fn().mockReturnValue({
+        amountHack: 6900n,
+        userPriceUsdCents: 69,
+        harjootCostUsdCents: 20,
+        grossMarginUsdCents: 49,
+        treasuryAddress: "0x000000000000000000000000000000000000bee",
+        hackTokenAddress: "0x000000000000000000000000000000000000ace",
+      }),
+    };
+  });
+
+  async function makeIssuer({ id, status = "approved", wallet = ISSUER_WALLET }) {
+    return User.create({
+      id,
+      wallet_address: wallet,
+      role: "issuer",
+      name: "Edu",
+      email: "edu@x.com",
+      nonce: crypto.randomBytes(16).toString("hex"),
+      educator_approval_status: status,
+    });
+  }
+
+  async function makeStudent({ id, wallet = STUDENT_WALLET }) {
+    return User.create({
+      id,
+      wallet_address: wallet,
+      role: "student",
+      name: "Sty",
+      email: "sty@x.com",
+      nonce: crypto.randomBytes(16).toString("hex"),
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Happy path
+  // ---------------------------------------------------------------------------
+
+  test("returns ok with price + talent when educator is approved and student exists", async () => {
+    const educator = await makeIssuer({ id: 1 });
+    await makeStudent({ id: 2 });
+
+    const result = await precheckCertificate({
+      models,
+      paymentService,
+      educator,
+      studentWallet: STUDENT_WALLET,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.price).toEqual({
+      amountHack: 6900n,
+      amountHackString: "6900",
+      userPriceUsdCents: 69,
+      treasuryAddress: "0x000000000000000000000000000000000000bee",
+      hackTokenAddress: "0x000000000000000000000000000000000000ace",
+    });
+    expect(result.talent).toEqual({ id: 2, walletAddress: STUDENT_WALLET });
+    expect(paymentService.calculateMintPrice).toHaveBeenCalledTimes(1);
+  });
+
+  test("lowercases the studentWallet before lookup", async () => {
+    const educator = await makeIssuer({ id: 1 });
+    await makeStudent({ id: 2 });
+
+    const result = await precheckCertificate({
+      models,
+      paymentService,
+      educator,
+      studentWallet: STUDENT_WALLET.toUpperCase().replace(/X/g, "x"), // mixed case
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.talent.walletAddress).toBe(STUDENT_WALLET);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Educator gates
+  // ---------------------------------------------------------------------------
+
+  test("returns EDUCATOR_NOT_APPROVED when status is pending_approval", async () => {
+    const educator = await makeIssuer({ id: 1, status: "pending_approval" });
+    await makeStudent({ id: 2 });
+
+    const result = await precheckCertificate({
+      models,
+      paymentService,
+      educator,
+      studentWallet: STUDENT_WALLET,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "EDUCATOR_NOT_APPROVED" });
+    expect(paymentService.calculateMintPrice).not.toHaveBeenCalled();
+  });
+
+  test("returns EDUCATOR_NOT_APPROVED when status is rejected", async () => {
+    const educator = await makeIssuer({ id: 1, status: "rejected" });
+    await makeStudent({ id: 2 });
+
+    const result = await precheckCertificate({
+      models,
+      paymentService,
+      educator,
+      studentWallet: STUDENT_WALLET,
+    });
+
+    expect(result.reason).toBe("EDUCATOR_NOT_APPROVED");
+  });
+
+  test("returns EDUCATOR_NOT_APPROVED when status is null", async () => {
+    // A non-issuer (or legacy) row with NULL status must not slip through.
+    const educator = await makeIssuer({ id: 1, status: null });
+
+    const result = await precheckCertificate({
+      models,
+      paymentService,
+      educator,
+      studentWallet: STUDENT_WALLET,
+    });
+
+    expect(result.reason).toBe("EDUCATOR_NOT_APPROVED");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Talent gates
+  // ---------------------------------------------------------------------------
+
+  test("returns TALENT_NOT_FOUND when no user has that wallet", async () => {
+    const educator = await makeIssuer({ id: 1 });
+
+    const result = await precheckCertificate({
+      models,
+      paymentService,
+      educator,
+      studentWallet: STUDENT_WALLET,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "TALENT_NOT_FOUND" });
+  });
+
+  test("returns TALENT_NOT_FOUND when the wallet belongs to a recruiter, not a student", async () => {
+    const educator = await makeIssuer({ id: 1 });
+    await User.create({
+      id: 2,
+      wallet_address: RECRUITER_WALLET,
+      role: "recruiter",
+      name: "Rec",
+      email: "r@x.com",
+      nonce: crypto.randomBytes(16).toString("hex"),
+    });
+
+    const result = await precheckCertificate({
+      models,
+      paymentService,
+      educator,
+      studentWallet: RECRUITER_WALLET,
+    });
+
+    expect(result.reason).toBe("TALENT_NOT_FOUND");
+  });
+
+  test("returns TALENT_NOT_FOUND when the wallet belongs to another issuer", async () => {
+    const educator = await makeIssuer({ id: 1 });
+    await makeIssuer({ id: 2, wallet: "0x4444444444444444444444444444444444444444" });
+
+    const result = await precheckCertificate({
+      models,
+      paymentService,
+      educator,
+      studentWallet: "0x4444444444444444444444444444444444444444",
+    });
+
+    expect(result.reason).toBe("TALENT_NOT_FOUND");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Programmer errors
+  // ---------------------------------------------------------------------------
+
+  test("throws TypeError when models is missing", async () => {
+    const educator = await makeIssuer({ id: 1 });
+    await expect(
+      precheckCertificate({ paymentService, educator, studentWallet: STUDENT_WALLET }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError when paymentService is missing", async () => {
+    const educator = await makeIssuer({ id: 1 });
+    await expect(
+      precheckCertificate({ models, educator, studentWallet: STUDENT_WALLET }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError when educator is missing", async () => {
+    await expect(
+      precheckCertificate({ models, paymentService, studentWallet: STUDENT_WALLET }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError on a malformed studentWallet", async () => {
+    const educator = await makeIssuer({ id: 1 });
+    await expect(
+      precheckCertificate({ models, paymentService, educator, studentWallet: "not-a-wallet" }),
+    ).rejects.toThrow(TypeError);
+    await expect(
+      precheckCertificate({ models, paymentService, educator, studentWallet: "0xshort" }),
+    ).rejects.toThrow(TypeError);
+  });
+});

--- a/backend/harjoot/usecases/__tests__/talentInvitation.test.js
+++ b/backend/harjoot/usecases/__tests__/talentInvitation.test.js
@@ -1,0 +1,337 @@
+// backend/harjoot/usecases/__tests__/talentInvitation.test.js
+//
+// Unit tests for the Section 5 invitation flow. SQLite in-memory exercises
+// the real Sequelize persistence path; emailService is mocked so we can
+// inspect the side effects without actually sending mail.
+
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+
+const { inviteTalent } = require("../inviteTalent");
+const { claimInvitation } = require("../claimInvitation");
+
+jest.setTimeout(10000);
+
+describe("Section 5 talent invitation use cases", () => {
+  let sequelize;
+  let User, Student, Issuer, Recruiter, UserSession, Certificate, TalentInvitation;
+  let models;
+  let emailService;
+
+  const ISSUER_WALLET = "0x1111111111111111111111111111111111111111";
+  const ISSUER_WALLET_2 = "0x3333333333333333333333333333333333333333";
+  const STUDENT_WALLET = "0x2222222222222222222222222222222222222222";
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    const { DataTypes } = SequelizePkg;
+
+    User = require("../../../models/users")(sequelize, DataTypes);
+    Student = require("../../../models/students")(sequelize, DataTypes);
+    Student.rawAttributes.wallet_address.unique = true;
+    Issuer = require("../../../models/issuers")(sequelize, DataTypes);
+    Recruiter = require("../../../models/recruiters")(sequelize, DataTypes);
+    UserSession = require("../../../models/userSessions")(sequelize, DataTypes);
+    Certificate = require("../../../models/certificates")(sequelize, DataTypes);
+    TalentInvitation = require("../../../models/talentInvitations")(sequelize, DataTypes);
+
+    const allModels = { User, Student, Issuer, Recruiter, UserSession, Certificate, TalentInvitation };
+    Object.values(allModels).forEach((m) => m.associate && m.associate(allModels));
+
+    await sequelize.sync({ force: true });
+    models = allModels;
+
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    if (sequelize) await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+    emailService = {
+      sendInvite: jest.fn().mockResolvedValue(undefined),
+      notifyEducatorClaimed: jest.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  async function makeApprovedIssuer({ id, wallet = ISSUER_WALLET, email = "edu@example.com", name = "Edu" }) {
+    const user = await User.create({
+      id,
+      wallet_address: wallet,
+      role: "issuer",
+      name,
+      email,
+      nonce: crypto.randomBytes(16).toString("hex"),
+      educator_approval_status: "approved",
+    });
+    await Issuer.create({ wallet_address: wallet, organization_name: "Acme Academy" });
+    return user;
+  }
+
+  // ===========================================================================
+  // inviteTalent
+  // ===========================================================================
+
+  describe("inviteTalent", () => {
+    test("creates a pending talent_invitations row (lowercased wallet + email)", async () => {
+      const educator = await makeApprovedIssuer({ id: 1 });
+
+      const result = await inviteTalent({
+        models,
+        emailService,
+        educator,
+        studentWallet: "0xABCDEF1111111111111111111111111111111111",
+        email: "Talent@Example.com",
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.invitation.educator_user_id).toBe(1);
+      expect(result.invitation.student_wallet_address).toBe("0xabcdef1111111111111111111111111111111111");
+      expect(result.invitation.email).toBe("talent@example.com");
+      expect(result.invitation.status).toBe("pending");
+    });
+
+    test("triggers emailService.sendInvite with to + wallet + educator name + message", async () => {
+      const educator = await makeApprovedIssuer({ id: 2, name: "Sofia" });
+
+      await inviteTalent({
+        models,
+        emailService,
+        educator,
+        studentWallet: STUDENT_WALLET,
+        email: "t@example.com",
+        message: "  Curso de fundamentos  ",
+      });
+
+      expect(emailService.sendInvite).toHaveBeenCalledTimes(1);
+      expect(emailService.sendInvite).toHaveBeenCalledWith({
+        to: "t@example.com",
+        walletAddress: STUDENT_WALLET,
+        educatorName: "Sofia",
+        message: "Curso de fundamentos", // trimmed
+      });
+    });
+
+    test("dedupes: a second call for the same educator+wallet does NOT create a duplicate row", async () => {
+      const educator = await makeApprovedIssuer({ id: 3 });
+
+      const first = await inviteTalent({
+        models,
+        emailService,
+        educator,
+        studentWallet: STUDENT_WALLET,
+        email: "t@example.com",
+      });
+      const second = await inviteTalent({
+        models,
+        emailService,
+        educator,
+        studentWallet: STUDENT_WALLET,
+        email: "t@example.com",
+      });
+
+      expect(first.ok).toBe(true);
+      expect(second.ok).toBe(false);
+      expect(second.reason).toBe("INVITE_ALREADY_PENDING");
+      expect(emailService.sendInvite).toHaveBeenCalledTimes(1); // no second email
+
+      const count = await TalentInvitation.count({
+        where: { educator_user_id: 3, student_wallet_address: STUDENT_WALLET },
+      });
+      expect(count).toBe(1);
+    });
+
+    test("DOES NOT undo the invitation row when the email throws", async () => {
+      const educator = await makeApprovedIssuer({ id: 4 });
+      emailService.sendInvite.mockRejectedValue(new Error("Resend down"));
+
+      const result = await inviteTalent({
+        models,
+        emailService,
+        educator,
+        studentWallet: STUDENT_WALLET,
+        email: "t@example.com",
+      });
+
+      expect(result.ok).toBe(true);
+      const persisted = await TalentInvitation.findByPk(result.invitation.id);
+      expect(persisted).not.toBeNull();
+      expect(persisted.status).toBe("pending");
+    });
+
+    test("throws TypeError on missing dependencies", async () => {
+      const educator = await makeApprovedIssuer({ id: 5 });
+      await expect(
+        inviteTalent({ emailService, educator, studentWallet: STUDENT_WALLET, email: "t@x.com" }),
+      ).rejects.toThrow(TypeError);
+      await expect(
+        inviteTalent({ models, educator, studentWallet: STUDENT_WALLET, email: "t@x.com" }),
+      ).rejects.toThrow(TypeError);
+      await expect(
+        inviteTalent({ models, emailService, studentWallet: STUDENT_WALLET, email: "t@x.com" }),
+      ).rejects.toThrow(TypeError);
+    });
+
+    test("throws TypeError on blank wallet or email", async () => {
+      const educator = await makeApprovedIssuer({ id: 6 });
+      await expect(
+        inviteTalent({ models, emailService, educator, studentWallet: "   ", email: "t@x.com" }),
+      ).rejects.toThrow(TypeError);
+      await expect(
+        inviteTalent({ models, emailService, educator, studentWallet: STUDENT_WALLET, email: "  " }),
+      ).rejects.toThrow(TypeError);
+    });
+  });
+
+  // ===========================================================================
+  // claimInvitation
+  // ===========================================================================
+
+  describe("claimInvitation", () => {
+    test("no pending invitation → fast no-op, returns counts=0", async () => {
+      const result = await claimInvitation({
+        models,
+        emailService,
+        studentWallet: STUDENT_WALLET,
+      });
+
+      expect(result).toEqual({ ok: true, claimedCount: 0, notifiedCount: 0 });
+      expect(emailService.notifyEducatorClaimed).not.toHaveBeenCalled();
+    });
+
+    test("a single pending invitation is marked claimed and the educator is notified", async () => {
+      const educator = await makeApprovedIssuer({ id: 10, email: "edu@x.com", name: "Sofia" });
+      await TalentInvitation.create({
+        educator_user_id: 10,
+        student_wallet_address: STUDENT_WALLET,
+        email: "t@x.com",
+        status: "pending",
+      });
+
+      const result = await claimInvitation({
+        models,
+        emailService,
+        studentWallet: STUDENT_WALLET,
+        studentUser: { name: "Sty" },
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.claimedCount).toBe(1);
+      expect(result.notifiedCount).toBe(1);
+
+      const reloaded = await TalentInvitation.findOne({ where: { educator_user_id: 10 } });
+      expect(reloaded.status).toBe("claimed");
+      expect(reloaded.claimed_at).toBeInstanceOf(Date);
+
+      expect(emailService.notifyEducatorClaimed).toHaveBeenCalledWith({
+        to: "edu@x.com",
+        educatorName: "Sofia",
+        studentWallet: STUDENT_WALLET,
+        studentName: "Sty",
+      });
+    });
+
+    test("multiple pending invitations from different educators are ALL claimed and notified", async () => {
+      const eduA = await makeApprovedIssuer({ id: 20, wallet: ISSUER_WALLET, email: "a@x.com", name: "A" });
+      const eduB = await makeApprovedIssuer({ id: 21, wallet: ISSUER_WALLET_2, email: "b@x.com", name: "B" });
+      await TalentInvitation.create({
+        educator_user_id: eduA.id,
+        student_wallet_address: STUDENT_WALLET,
+        email: "t@x.com",
+        status: "pending",
+      });
+      await TalentInvitation.create({
+        educator_user_id: eduB.id,
+        student_wallet_address: STUDENT_WALLET,
+        email: "t@x.com",
+        status: "pending",
+      });
+
+      const result = await claimInvitation({
+        models,
+        emailService,
+        studentWallet: STUDENT_WALLET,
+      });
+
+      expect(result.claimedCount).toBe(2);
+      expect(result.notifiedCount).toBe(2);
+      const stillPending = await TalentInvitation.count({
+        where: { student_wallet_address: STUDENT_WALLET, status: "pending" },
+      });
+      expect(stillPending).toBe(0);
+    });
+
+    test("invitation is claimed even when the educator notification email throws", async () => {
+      await makeApprovedIssuer({ id: 30 });
+      await TalentInvitation.create({
+        educator_user_id: 30,
+        student_wallet_address: STUDENT_WALLET,
+        email: "t@x.com",
+        status: "pending",
+      });
+      emailService.notifyEducatorClaimed.mockRejectedValue(new Error("Resend down"));
+
+      const result = await claimInvitation({
+        models,
+        emailService,
+        studentWallet: STUDENT_WALLET,
+      });
+
+      expect(result.claimedCount).toBe(1);
+      expect(result.notifiedCount).toBe(0); // email failed but claim succeeded
+
+      const reloaded = await TalentInvitation.findOne({ where: { educator_user_id: 30 } });
+      expect(reloaded.status).toBe("claimed");
+    });
+
+    test("educator without an email on file: invitation claimed, notification skipped", async () => {
+      // Create educator WITHOUT an email
+      const educator = await User.create({
+        id: 40,
+        wallet_address: ISSUER_WALLET,
+        role: "issuer",
+        name: "Anon",
+        nonce: crypto.randomBytes(16).toString("hex"),
+        educator_approval_status: "approved",
+        // email omitted (nullable)
+      });
+      await Issuer.create({ wallet_address: ISSUER_WALLET, organization_name: "Acme" });
+      await TalentInvitation.create({
+        educator_user_id: educator.id,
+        student_wallet_address: STUDENT_WALLET,
+        email: "t@x.com",
+        status: "pending",
+      });
+
+      const result = await claimInvitation({
+        models,
+        emailService,
+        studentWallet: STUDENT_WALLET,
+      });
+
+      expect(result.claimedCount).toBe(1);
+      expect(result.notifiedCount).toBe(0);
+      expect(emailService.notifyEducatorClaimed).not.toHaveBeenCalled();
+    });
+
+    test("throws TypeError on missing dependencies", async () => {
+      await expect(
+        claimInvitation({ emailService, studentWallet: STUDENT_WALLET }),
+      ).rejects.toThrow(TypeError);
+      await expect(
+        claimInvitation({ models, studentWallet: STUDENT_WALLET }),
+      ).rejects.toThrow(TypeError);
+      await expect(
+        claimInvitation({ models, emailService, studentWallet: "  " }),
+      ).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/backend/harjoot/usecases/activateMembership.js
+++ b/backend/harjoot/usecases/activateMembership.js
@@ -1,0 +1,59 @@
+// backend/harjoot/usecases/activateMembership.js
+//
+// DS Section 2 — register a freshly-created HackChain user inside Harjoot
+// as a partner_external_user and persist the resulting membership expiry
+// on the user row.
+//
+// This use case is the post-commit hook for POST /api/users/register. It
+// MUST NEVER throw — a Harjoot outage cannot prevent a user from finishing
+// their registration locally. On failure we log, return a Result indicating
+// what went wrong, and let middleware/harjootAccess.js re-activate lazily on
+// the first protected request (DS decision documented in Section 2 v5).
+
+const LOG_PREFIX = "[harjoot:membership]";
+
+/**
+ * Activate the Harjoot membership for a newly registered user.
+ *
+ * @param {object} params
+ * @param {object} params.client    A Harjoot client (from createHarjootClient).
+ * @param {object} params.models    The Sequelize `db` object (needs db.User).
+ * @param {"student"|"issuer"|"recruiter"} params.role
+ * @param {object} params.user      Full User row from the registration tx.
+ * @param {object} params.profile   Role-specific profile (student/issuer/recruiter row).
+ * @returns {Promise<{ ok: boolean, expiresAt: string|null, error: Error|null }>}
+ */
+async function activateMembership({ client, models, role, user, profile }) {
+  if (!client || !models || !models.User) {
+    // Caller bug — surface it loudly. This is NOT an upstream failure.
+    throw new TypeError("activateMembership requires { client, models.User, role, user, profile }");
+  }
+
+  try {
+    const response = await client.activateAccess(role, user, profile);
+    const expiresAt = response && response.membership && response.membership.expires_at
+      ? response.membership.expires_at
+      : null;
+
+    if (expiresAt) {
+      await models.User.update(
+        { harjoot_membership_expires_at: expiresAt },
+        { where: { id: user.id } },
+      );
+    }
+
+    console.log(
+      `${LOG_PREFIX} activated user_id=${user.id} role=${role}` +
+        ` expires_at=${expiresAt || "(none)"}`,
+    );
+    return { ok: true, expiresAt, error: null };
+  } catch (error) {
+    // Never throw — registration must succeed even if Harjoot is unreachable.
+    console.error(
+      `${LOG_PREFIX} FAILED user_id=${user && user.id}: ${error.name || "Error"}: ${error.message}`,
+    );
+    return { ok: false, expiresAt: null, error };
+  }
+}
+
+module.exports = { activateMembership };

--- a/backend/harjoot/usecases/approveEducator.js
+++ b/backend/harjoot/usecases/approveEducator.js
@@ -1,0 +1,76 @@
+// backend/harjoot/usecases/approveEducator.js
+//
+// DS Section 2.5 — approve an educator that registered with status
+// 'pending_approval'. Sets the row to approved, captures who approved and
+// when, and triggers the notification email. Email failures are logged but
+// do NOT undo the approval (the user is still approved in DB).
+//
+// Returns a Result-style object; throws ONLY on programmer errors (missing
+// deps, invalid args).
+
+const LOG_PREFIX = "[approveEducator]";
+
+/**
+ * Approve a pending educator account.
+ *
+ * @param {object} params
+ * @param {object} params.models        The Sequelize `db` object (db.User).
+ * @param {object} params.emailService  Must expose notifyEducatorApproved.
+ * @param {number} params.userId        Target educator's user id.
+ * @param {number} params.adminId       Admin user id (recorded as approved_by).
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   reason?: "USER_NOT_FOUND" | "NOT_AN_ISSUER" | "ALREADY_APPROVED",
+ *   user?: { id: number, status: "approved", approved_at: Date },
+ * }>}
+ */
+async function approveEducator({ models, emailService, userId, adminId }) {
+  if (!models || !models.User || !emailService) {
+    throw new TypeError(
+      "approveEducator requires { models.User, emailService, userId, adminId }",
+    );
+  }
+  if (userId === undefined || userId === null) {
+    throw new TypeError("approveEducator requires a userId");
+  }
+
+  const user = await models.User.findByPk(userId);
+  if (!user) {
+    return { ok: false, reason: "USER_NOT_FOUND" };
+  }
+  if (user.role !== "issuer") {
+    return { ok: false, reason: "NOT_AN_ISSUER" };
+  }
+  if (user.educator_approval_status === "approved") {
+    return { ok: false, reason: "ALREADY_APPROVED" };
+  }
+
+  const approvedAt = new Date();
+  await user.update({
+    educator_approval_status: "approved",
+    approved_at: approvedAt,
+    approved_by: adminId,
+    rejection_reason: null, // wipe any prior rejection
+  });
+
+  // Email is a side effect — failures must not invalidate the approval.
+  try {
+    if (user.email) {
+      await emailService.notifyEducatorApproved({ to: user.email, name: user.name });
+    } else {
+      console.warn(`${LOG_PREFIX} no email on file for user_id=${userId}; skipped notification`);
+    }
+  } catch (err) {
+    console.error(
+      `${LOG_PREFIX} email notification failed user_id=${userId}: ${err.name || "Error"}: ${err.message}`,
+    );
+  }
+
+  console.log(`${LOG_PREFIX} approved user_id=${userId} by admin_id=${adminId}`);
+  return {
+    ok: true,
+    user: { id: user.id, status: "approved", approved_at: approvedAt },
+  };
+}
+
+module.exports = { approveEducator };

--- a/backend/harjoot/usecases/checkPartnerHealth.js
+++ b/backend/harjoot/usecases/checkPartnerHealth.js
@@ -1,0 +1,88 @@
+// backend/harjoot/usecases/checkPartnerHealth.js
+//
+// DS Section 0 — verify the Harjoot partner API key is valid at server startup
+// and cache the partner config in memory for the lifetime of the process.
+//
+// This use case NEVER throws. A failed health check is logged but does not
+// abort the server — Harjoot being temporarily unreachable should not take
+// HackChain down. Routes that need the cached info handle a null cache
+// gracefully and fall back to making a fresh request through the client.
+//
+// On success the cache is updated with the latest response. On failure the
+// previous successful cache is preserved (last-known-good) so a transient
+// outage doesn't lose what we already learned about the partner.
+
+const LOG_PREFIX = "[harjoot:health]";
+
+// ---------------------------------------------------------------------------
+// Module-scope cache. Survives the lifetime of the Node process.
+// ---------------------------------------------------------------------------
+let cachedPartnerInfo = null;
+let lastCheckedAt = null;
+let lastError = null;
+
+/**
+ * Run the partner health check against Harjoot and update the in-memory cache.
+ * Returns a Result-style object; never throws.
+ *
+ * @param {object} client  A Harjoot client (from createHarjootClient).
+ * @returns {Promise<{ ok: boolean, info: object|null, error: Error|null }>}
+ */
+async function checkPartnerHealth(client) {
+  try {
+    const info = await client.getPartnerInfo();
+    cachedPartnerInfo = info;
+    lastCheckedAt = new Date();
+    lastError = null;
+
+    const slug = info && info.partner && info.partner.slug ? info.partner.slug : "?";
+    const active = info && info.partner && info.partner.active != null ? info.partner.active : "?";
+    const modes = info && Array.isArray(info.modes) ? info.modes.join(",") : "";
+    console.log(`${LOG_PREFIX} OK partner=${slug} active=${active} modes=${modes}`);
+
+    return { ok: true, info, error: null };
+  } catch (error) {
+    lastCheckedAt = new Date();
+    lastError = error;
+    // Do NOT throw — startup must continue.
+    console.error(`${LOG_PREFIX} FAILED — ${error.name || "Error"}: ${error.message}`);
+    return { ok: false, info: cachedPartnerInfo, error };
+  }
+}
+
+/**
+ * Get the most recent successful partner info, or null if no successful check
+ * has ever run.
+ */
+function getCachedPartnerInfo() {
+  return cachedPartnerInfo;
+}
+
+/**
+ * Snapshot of the cache state — useful for /health endpoints and debugging.
+ */
+function getHealthState() {
+  return {
+    hasCache: cachedPartnerInfo !== null,
+    lastCheckedAt,
+    lastError: lastError
+      ? { name: lastError.name, message: lastError.message, code: lastError.code }
+      : null,
+  };
+}
+
+/**
+ * Reset all module-scope state. Test-only — do not call from production code.
+ */
+function __resetForTests() {
+  cachedPartnerInfo = null;
+  lastCheckedAt = null;
+  lastError = null;
+}
+
+module.exports = {
+  checkPartnerHealth,
+  getCachedPartnerInfo,
+  getHealthState,
+  __resetForTests,
+};

--- a/backend/harjoot/usecases/claimInvitation.js
+++ b/backend/harjoot/usecases/claimInvitation.js
@@ -1,0 +1,94 @@
+// backend/harjoot/usecases/claimInvitation.js
+//
+// DS Section 5 — when a freshly registered student matches a wallet that an
+// educator had previously invited, mark every pending invitation for that
+// wallet as claimed and notify each educator so they can retry issuance.
+//
+// Designed as a best-effort post-registration hook:
+//  - If there are no pending invitations, this is a quick no-op.
+//  - If one or more exist, all are claimed in a single pass.
+//  - Email failures do not block the claim — the DB transition is the source
+//    of truth; educators are informed best-effort.
+//
+// Like the other Section 5 use cases, this never throws on upstream failures —
+// only on programmer errors (missing deps).
+
+const LOG_PREFIX = "[claimInvitation]";
+
+/**
+ * Claim all pending invitations matching `studentWallet` and notify the
+ * educators who issued them.
+ *
+ * @param {object} params
+ * @param {object} params.models             db (TalentInvitation, User).
+ * @param {object} params.emailService       Must expose notifyEducatorClaimed().
+ * @param {string} params.studentWallet      The talent's wallet (just registered).
+ * @param {object} [params.studentUser]      Optional — the freshly-created
+ *                                           student User row, to pass the name
+ *                                           through to the educator email.
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   claimedCount: number,
+ *   notifiedCount: number,
+ * }>}
+ */
+async function claimInvitation({ models, emailService, studentWallet, studentUser }) {
+  if (!models || !models.TalentInvitation || !models.User || !emailService) {
+    throw new TypeError(
+      "claimInvitation requires { models.TalentInvitation, models.User, emailService, studentWallet }",
+    );
+  }
+  if (typeof studentWallet !== "string" || !studentWallet.trim()) {
+    throw new TypeError("claimInvitation requires a non-empty studentWallet");
+  }
+
+  const normalizedWallet = studentWallet.toLowerCase();
+
+  const pending = await models.TalentInvitation.findAll({
+    where: { student_wallet_address: normalizedWallet, status: "pending" },
+  });
+
+  if (pending.length === 0) {
+    // Fast path: most registrations have no invitation waiting. Cheap no-op.
+    return { ok: true, claimedCount: 0, notifiedCount: 0 };
+  }
+
+  const claimedAt = new Date();
+  let notifiedCount = 0;
+
+  for (const invite of pending) {
+    await invite.update({ status: "claimed", claimed_at: claimedAt });
+
+    // Best-effort educator notification — load the educator row to get their
+    // email + name. If any of this fails, log and continue with the next one.
+    try {
+      const educator = await models.User.findByPk(invite.educator_user_id, {
+        attributes: ["email", "name", "lastname"],
+      });
+      if (educator && educator.email) {
+        await emailService.notifyEducatorClaimed({
+          to: educator.email,
+          educatorName: educator.name || educator.lastname || null,
+          studentWallet: normalizedWallet,
+          studentName: studentUser ? (studentUser.name || null) : null,
+        });
+        notifiedCount += 1;
+      } else {
+        console.warn(
+          `${LOG_PREFIX} educator_user_id=${invite.educator_user_id} has no email; skipped notification`,
+        );
+      }
+    } catch (err) {
+      console.error(
+        `${LOG_PREFIX} email failed invitation_id=${invite.id}: ${err.name || "Error"}: ${err.message}`,
+      );
+    }
+  }
+
+  console.log(
+    `${LOG_PREFIX} claimed=${pending.length} notified=${notifiedCount} wallet=${normalizedWallet}`,
+  );
+  return { ok: true, claimedCount: pending.length, notifiedCount };
+}
+
+module.exports = { claimInvitation };

--- a/backend/harjoot/usecases/ensureMembership.js
+++ b/backend/harjoot/usecases/ensureMembership.js
@@ -1,0 +1,139 @@
+// backend/harjoot/usecases/ensureMembership.js
+//
+// DS Section 3 — verify that the authenticated user has an active Harjoot
+// membership and lazily refresh it via Harjoot when the local cache is stale.
+//
+// Strategy (cache-aside on the User row):
+//
+//   1. Read `users.harjoot_membership_expires_at`. If it is in the future,
+//      we trust it and skip the network — that's the hot path.
+//
+//   2. Otherwise call `client.checkAccess()`:
+//        - active=true  → Harjoot confirms membership, refresh the local
+//                         expiry and return ok with source="check".
+//        - active=false → Harjoot says it expired. Try to reactivate (free
+//                         in pay-per-mint mode) via `client.activateAccess()`;
+//                         persist the new expiry and return source="reactivated".
+//
+//   3. If anything goes wrong talking to Harjoot, "soft-fail": log a warning
+//      and return ok=true with soft_failed=true. Per the DS, an expired or
+//      uncheckable membership must NOT block users — issuance has its own
+//      cost gate via $HACK payment, so allowing through here is safe.
+//
+// The use case throws ONLY on programmer errors (missing deps, invalid args).
+// All upstream failures are mapped to a Result-style return.
+
+const LOG_PREFIX = "[harjoot:access]";
+
+const USER_ATTRIBUTES = ["id", "wallet_address", "role", "harjoot_membership_expires_at"];
+
+async function loadProfile(models, role, walletAddress) {
+  switch (role) {
+    case "student":
+      return await models.Student.findOne({ where: { wallet_address: walletAddress } });
+    case "issuer":
+      return await models.Issuer.findOne({ where: { wallet_address: walletAddress } });
+    case "recruiter":
+      return await models.Recruiter.findOne({ where: { wallet_address: walletAddress } });
+    default:
+      return null;
+  }
+}
+
+function isFuture(value) {
+  if (!value) return false;
+  const t = new Date(value).getTime();
+  return Number.isFinite(t) && t > Date.now();
+}
+
+/**
+ * Ensure the user identified by `userId` has an active Harjoot membership,
+ * refreshing it via Harjoot when the locally cached expiry is stale.
+ *
+ * @param {object} params
+ * @param {object} params.client    A Harjoot client (from createHarjootClient).
+ * @param {object} params.models    The Sequelize `db` object (User, Student,
+ *                                  Issuer, Recruiter).
+ * @param {number} params.userId    The HackChain user id (req.auth.sub).
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   source?: "cache" | "check" | "reactivated",
+ *   soft_failed?: boolean,
+ *   expiresAt: string | null,
+ *   reason?: string,
+ *   error?: Error,
+ * }>}
+ */
+async function ensureMembership({ client, models, userId }) {
+  if (!client || !models || !models.User) {
+    throw new TypeError("ensureMembership requires { client, models.User, userId }");
+  }
+  if (userId === undefined || userId === null) {
+    throw new TypeError("ensureMembership requires a userId");
+  }
+
+  const user = await models.User.findOne({
+    where: { id: userId },
+    attributes: USER_ATTRIBUTES,
+  });
+
+  if (!user) {
+    // Programmer-ish: middleware called for a user that no longer exists.
+    // Return a Result so the caller can decide (typically: log and pass).
+    return { ok: false, reason: "USER_NOT_FOUND", expiresAt: null };
+  }
+
+  // ---- Hot path: local cache still fresh ----
+  if (isFuture(user.harjoot_membership_expires_at)) {
+    return {
+      ok: true,
+      source: "cache",
+      expiresAt: user.harjoot_membership_expires_at,
+    };
+  }
+
+  // ---- Cold path: ask Harjoot ----
+  try {
+    const access = await client.checkAccess(user.wallet_address, user.role);
+
+    if (access && access.active) {
+      const newExpiresAt = access.expires_at || null;
+      if (newExpiresAt) {
+        await models.User.update(
+          { harjoot_membership_expires_at: newExpiresAt },
+          { where: { id: userId } },
+        );
+      }
+      return { ok: true, source: "check", expiresAt: newExpiresAt };
+    }
+
+    // Harjoot says inactive — try to reactivate.
+    const profile = await loadProfile(models, user.role, user.wallet_address);
+    const activation = await client.activateAccess(user.role, user, profile);
+    const reactivatedAt =
+      activation && activation.membership && activation.membership.expires_at
+        ? activation.membership.expires_at
+        : null;
+
+    if (reactivatedAt) {
+      await models.User.update(
+        { harjoot_membership_expires_at: reactivatedAt },
+        { where: { id: userId } },
+      );
+    }
+
+    return { ok: true, source: "reactivated", expiresAt: reactivatedAt };
+  } catch (error) {
+    console.warn(
+      `${LOG_PREFIX} soft-fail userId=${userId}: ${error.name || "Error"}: ${error.message}`,
+    );
+    return {
+      ok: true,
+      soft_failed: true,
+      error,
+      expiresAt: user.harjoot_membership_expires_at || null,
+    };
+  }
+}
+
+module.exports = { ensureMembership };

--- a/backend/harjoot/usecases/inviteTalent.js
+++ b/backend/harjoot/usecases/inviteTalent.js
@@ -1,0 +1,90 @@
+// backend/harjoot/usecases/inviteTalent.js
+//
+// DS Section 5 — when an educator tries to issue a certificate to a wallet
+// that is not yet a HackChain user, this use case stores a pending invitation
+// and emails the talent so they can register and claim the wallet.
+//
+// Dedupe rule: if there is already a pending invitation from this educator
+// to this wallet, do NOT create a duplicate row — return INVITE_ALREADY_PENDING.
+// This avoids spamming the talent if an educator clicks invite twice.
+//
+// Email failures are non-fatal: the invitation row is still created. The
+// educator can re-trigger later if they suspect the email never arrived.
+
+const LOG_PREFIX = "[inviteTalent]";
+
+/**
+ * Send a talent invitation.
+ *
+ * @param {object} params
+ * @param {object} params.models             db (TalentInvitation, User).
+ * @param {object} params.emailService       Must expose sendInvite().
+ * @param {object} params.educator           The educator User row (must be issuer + approved).
+ * @param {string} params.studentWallet      Target wallet address (0x-prefixed).
+ * @param {string} params.email              Email to deliver the invite.
+ * @param {string} [params.message]          Optional personal message from the educator.
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   reason?: "INVITE_ALREADY_PENDING",
+ *   invitation?: object,
+ * }>}
+ */
+async function inviteTalent({ models, emailService, educator, studentWallet, email, message }) {
+  if (!models || !models.TalentInvitation || !emailService || !educator) {
+    throw new TypeError(
+      "inviteTalent requires { models.TalentInvitation, emailService, educator, studentWallet, email }",
+    );
+  }
+  if (typeof studentWallet !== "string" || !studentWallet.trim()) {
+    throw new TypeError("inviteTalent requires a non-empty studentWallet");
+  }
+  if (typeof email !== "string" || !email.trim()) {
+    throw new TypeError("inviteTalent requires a non-empty email");
+  }
+
+  const normalizedWallet = studentWallet.toLowerCase();
+  const normalizedEmail = email.trim().toLowerCase();
+
+  // Dedupe — silently swallow re-clicks from the educator.
+  const existing = await models.TalentInvitation.findOne({
+    where: {
+      educator_user_id: educator.id,
+      student_wallet_address: normalizedWallet,
+      status: "pending",
+    },
+  });
+  if (existing) {
+    console.log(
+      `${LOG_PREFIX} duplicate-suppressed educator_user_id=${educator.id} wallet=${normalizedWallet}`,
+    );
+    return { ok: false, reason: "INVITE_ALREADY_PENDING", invitation: existing };
+  }
+
+  const invitation = await models.TalentInvitation.create({
+    educator_user_id: educator.id,
+    student_wallet_address: normalizedWallet,
+    email: normalizedEmail,
+    status: "pending",
+  });
+
+  // Email is a side effect — failures must not undo the invitation row.
+  try {
+    await emailService.sendInvite({
+      to: normalizedEmail,
+      walletAddress: normalizedWallet,
+      educatorName: educator.name || educator.lastname || "An educator",
+      message: typeof message === "string" && message.trim() ? message.trim() : null,
+    });
+  } catch (err) {
+    console.error(
+      `${LOG_PREFIX} email failed educator_user_id=${educator.id} wallet=${normalizedWallet}: ${err.name || "Error"}: ${err.message}`,
+    );
+  }
+
+  console.log(
+    `${LOG_PREFIX} created invitation_id=${invitation.id} educator_user_id=${educator.id} wallet=${normalizedWallet}`,
+  );
+  return { ok: true, invitation };
+}
+
+module.exports = { inviteTalent };

--- a/backend/harjoot/usecases/issueCertificate.js
+++ b/backend/harjoot/usecases/issueCertificate.js
@@ -1,0 +1,313 @@
+// backend/harjoot/usecases/issueCertificate.js
+//
+// DS Section 4 orchestrator — turns a verified $HACK payment into a
+// fully-issued certificate. Wires together every Phase 7 building block:
+//
+//   1. defense-in-depth: re-validate educator approval + talent existence
+//      (the route's precheck is advisory only; we never trust the client).
+//   2. SHA-256 the PDF -> certificate_hash (UNIQUE in DB).
+//   3. paymentService.verifyHackPayment — Result-style. This is the
+//      operation that creates the `payments` row + enforces replay
+//      protection (its own tx_hash UNIQUE constraint).
+//   4. IPFS pin via injected ipfsUpload() -> tokenUri.
+//   5. harjootClient.uploadCertificate({ ..., processing.mode: 'hash_only' }).
+//   6. on-chain mint via mintAdapter -> { tokenId, txHash }.
+//   7. atomic INSERT of certificates + treasury_transfers_queue inside a
+//      Sequelize transaction.
+//
+// Failure boundary semantics:
+//   - Steps before the mint either return a clean Result (no chain mutation)
+//     or have already persisted the payment row, in which case we bubble up
+//     the failure with paymentId attached so ops can reconcile.
+//   - A failure AFTER mint (only the final persist) leaves the NFT on-chain
+//     with no DB row. We surface PERSIST_FAILED with tokenId + txHash so a
+//     reconciliation job can later create the missing rows; we do NOT try to
+//     burn the token (the contract is the source of truth — DB catches up).
+//
+// Idempotency: each call generates a fresh idempotency_key for Harjoot.
+// At our DB level, the payment_tx_hash UNIQUE constraint prevents two
+// concurrent /issue calls for the same payment from both minting.
+
+const crypto = require("crypto");
+
+const LOG_PREFIX = "[issueCertificate]";
+const WALLET_REGEX = /^0x[a-fA-F0-9]{40}$/;
+const TX_HASH_REGEX = /^0x[a-fA-F0-9]{64}$/;
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+function assertDeps({
+  models, paymentService, harjootClient, mintAdapter, ipfsUpload, provider,
+}) {
+  if (!models || !models.Certificate || !models.Payment || !models.TreasuryTransfer
+      || !models.User || !models.Issuer || !models.sequelize) {
+    throw new TypeError(
+      "issueCertificate requires { models.{Certificate, Payment, TreasuryTransfer, User, Issuer, sequelize} }",
+    );
+  }
+  if (!paymentService || typeof paymentService.verifyHackPayment !== "function"
+      || typeof paymentService.calculateMintPrice !== "function") {
+    throw new TypeError("issueCertificate requires paymentService { verifyHackPayment, calculateMintPrice }");
+  }
+  if (!harjootClient || typeof harjootClient.uploadCertificate !== "function") {
+    throw new TypeError("issueCertificate requires harjootClient.uploadCertificate");
+  }
+  if (!mintAdapter || typeof mintAdapter.mintCertificate !== "function") {
+    throw new TypeError("issueCertificate requires mintAdapter.mintCertificate");
+  }
+  if (typeof ipfsUpload !== "function") {
+    throw new TypeError("issueCertificate requires ipfsUpload(...) async function");
+  }
+  if (!provider || typeof provider.getTransactionReceipt !== "function") {
+    throw new TypeError("issueCertificate requires provider.getTransactionReceipt");
+  }
+}
+
+function assertInputs({
+  educator, studentWallet, title, issueDate, paymentTxHash, pdfBuffer,
+}) {
+  if (!educator || typeof educator !== "object" || !educator.wallet_address) {
+    throw new TypeError("issueCertificate requires an educator User row with wallet_address");
+  }
+  if (typeof studentWallet !== "string" || !WALLET_REGEX.test(studentWallet)) {
+    throw new TypeError("issueCertificate requires a valid studentWallet");
+  }
+  if (!title || typeof title !== "string" || !title.trim()) {
+    throw new TypeError("issueCertificate requires a non-empty title");
+  }
+  if (typeof issueDate !== "string" || !ISO_DATE_REGEX.test(issueDate)) {
+    throw new TypeError("issueCertificate requires issueDate as YYYY-MM-DD");
+  }
+  if (typeof paymentTxHash !== "string" || !TX_HASH_REGEX.test(paymentTxHash)) {
+    throw new TypeError("issueCertificate requires a 32-byte paymentTxHash");
+  }
+  if (!Buffer.isBuffer(pdfBuffer) || pdfBuffer.length === 0) {
+    throw new TypeError("issueCertificate requires a non-empty pdfBuffer");
+  }
+}
+
+function sha256(buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+/**
+ * @returns {Promise<
+ *   | { ok: true, certificate: { id, tokenId, txHash, certificateHash, tokenUri,
+ *                                verificationId, verificationUrl, qrUrl,
+ *                                paymentId, treasuryTransferId } }
+ *   | { ok: false, reason: string, ... }
+ * >}
+ */
+async function issueCertificate(params) {
+  const {
+    models, paymentService, harjootClient, mintAdapter, ipfsUpload, provider,
+    educator, studentWallet, title, description = null, issueDate,
+    paymentTxHash, pdfBuffer, pdfFileName = "certificate.pdf",
+  } = params;
+
+  assertDeps(params);
+  assertInputs(params);
+
+  // ---- 1. Defense-in-depth: educator approval + talent existence ------------
+  if (educator.educator_approval_status !== "approved") {
+    return { ok: false, reason: "EDUCATOR_NOT_APPROVED" };
+  }
+
+  const normalizedStudent = studentWallet.toLowerCase();
+  const talent = await models.User.findOne({
+    where: { wallet_address: normalizedStudent, role: "student" },
+    attributes: ["id", "wallet_address", "name", "email"],
+  });
+  if (!talent) {
+    return { ok: false, reason: "TALENT_NOT_FOUND" };
+  }
+
+  // Fetch issuer row for org name (passed to Harjoot for richer metadata).
+  const issuer = await models.Issuer.findOne({
+    where: { wallet_address: educator.wallet_address.toLowerCase() },
+    attributes: ["wallet_address", "organization_name"],
+  });
+  const organizationName = issuer ? issuer.organization_name : null;
+
+  // ---- 2. SHA-256 of the PDF ------------------------------------------------
+  const certificateHash = sha256(pdfBuffer);
+
+  // ---- 3. Verify HACK payment ----------------------------------------------
+  const pricing = paymentService.calculateMintPrice();
+  const paymentResult = await paymentService.verifyHackPayment({
+    models,
+    provider,
+    txHash: paymentTxHash,
+    expectedFrom: educator.wallet_address,
+    expectedAmountHack: pricing.amountHack,
+    purpose: "certificate_issuance",
+    pricing: {
+      harjootCostUsdCents: pricing.harjootCostUsdCents,
+      userPriceUsdCents: pricing.userPriceUsdCents,
+    },
+  });
+  if (!paymentResult.ok) {
+    // Bubble up the payment reason intact. The route turns it into HTTP.
+    return paymentResult;
+  }
+  const paymentId = paymentResult.payment.id;
+
+  // ---- 4. IPFS upload -------------------------------------------------------
+  let ipfsResult;
+  try {
+    ipfsResult = await ipfsUpload({
+      pdfBuffer,
+      pdfFileName,
+      title,
+      description,
+      studentWallet: talent.wallet_address,
+      certificateHash,
+      issueDate,
+    });
+  } catch (err) {
+    console.error(`${LOG_PREFIX} IPFS upload failed: ${err.message || err}`);
+    return {
+      ok: false,
+      reason: "IPFS_FAILED",
+      paymentId,
+      error: err.message || String(err),
+    };
+  }
+  const tokenUri = ipfsResult && ipfsResult.tokenUri;
+  if (!tokenUri || typeof tokenUri !== "string") {
+    return {
+      ok: false,
+      reason: "IPFS_FAILED",
+      paymentId,
+      error: "ipfsUpload did not return a tokenUri string",
+    };
+  }
+
+  // ---- 5. Harjoot uploadCertificate ----------------------------------------
+  const idempotencyKey = `cert-${crypto.randomUUID()}-v1`;
+  let harjootResp;
+  try {
+    harjootResp = await harjootClient.uploadCertificate({
+      idempotency_key: idempotencyKey,
+      processing: { mode: "hash_only" },
+      issuer: {
+        wallet_address: educator.wallet_address,
+        organization_name: organizationName,
+        email: educator.email || null,
+      },
+      student: {
+        wallet_address: talent.wallet_address,
+        name: talent.name || null,
+      },
+      certificate: {
+        title,
+        description,
+        issue_date: issueDate,
+        token_uri: tokenUri,
+        certificate_hash: certificateHash,
+      },
+      document: { hash: certificateHash },
+    });
+  } catch (err) {
+    console.error(`${LOG_PREFIX} Harjoot uploadCertificate failed: ${err.message || err}`);
+    return {
+      ok: false,
+      reason: "HARJOOT_UPLOAD_FAILED",
+      paymentId,
+      error: err.message || String(err),
+    };
+  }
+
+  // Optional fields — Harjoot's contract isn't 100% locked. Tolerate absence.
+  const certEnvelope = (harjootResp && harjootResp.certificate) || {};
+  const verificationId  = certEnvelope.verificationId || null;
+  const verificationUrl = certEnvelope.verification && certEnvelope.verification.url ? certEnvelope.verification.url : null;
+  const qrUrl           = certEnvelope.verification && certEnvelope.verification.qrCodeUrl ? certEnvelope.verification.qrCodeUrl : null;
+
+  // ---- 6. On-chain mint ----------------------------------------------------
+  let mintResult;
+  try {
+    mintResult = await mintAdapter.mintCertificate({
+      studentWallet: talent.wallet_address,
+      studentName: talent.name || "HackChain Talent",
+      courseName: title,
+      tokenUri,
+    });
+  } catch (err) {
+    console.error(`${LOG_PREFIX} mint failed: ${err.message || err}`);
+    return {
+      ok: false,
+      reason: "MINT_FAILED",
+      paymentId,
+      verificationId,
+      error: err.message || String(err),
+    };
+  }
+
+  // ---- 7. Atomic persistence (Certificate + TreasuryTransfer) --------------
+  let certificate;
+  let treasuryTransfer;
+  try {
+    await models.sequelize.transaction(async (t) => {
+      certificate = await models.Certificate.create({
+        issuer_wallet_address: educator.wallet_address.toLowerCase(),
+        student_wallet_address: talent.wallet_address,
+        title,
+        description,
+        certificate_hash: certificateHash,
+        blockchain_tx_hash: mintResult.txHash,
+        token_id: mintResult.tokenId.toString(),
+        issue_date: issueDate,
+        harjoot_verification_id: verificationId,
+        harjoot_verification_url: verificationUrl,
+        harjoot_qr_url: qrUrl,
+        payment_id: paymentId,
+        status: "issued",
+      }, { transaction: t });
+
+      treasuryTransfer = await models.TreasuryTransfer.create({
+        payment_id: paymentId,
+        amount_usdt_owed: (pricing.harjootCostUsdCents / 100).toFixed(4),
+        destination: "harjoot",
+        status: "pending",
+      }, { transaction: t });
+    });
+  } catch (err) {
+    // The NFT exists on-chain but the row didn't make it. Surface enough
+    // information for an ops reconciliation script to pick it up.
+    console.error(`${LOG_PREFIX} persist failed AFTER mint: ${err.message || err}`);
+    return {
+      ok: false,
+      reason: "PERSIST_FAILED",
+      paymentId,
+      verificationId,
+      tokenId: mintResult.tokenId.toString(),
+      txHash: mintResult.txHash,
+      certificateHash,
+      tokenUri,
+      error: err.message || String(err),
+    };
+  }
+
+  console.log(
+    `${LOG_PREFIX} issued cert_id=${certificate.id} token_id=${mintResult.tokenId} ` +
+      `student=${talent.wallet_address} verification_id=${verificationId}`,
+  );
+
+  return {
+    ok: true,
+    certificate: {
+      id: certificate.id,
+      tokenId: mintResult.tokenId.toString(),
+      txHash: mintResult.txHash,
+      certificateHash,
+      tokenUri,
+      verificationId,
+      verificationUrl,
+      qrUrl,
+      paymentId,
+      treasuryTransferId: treasuryTransfer.id,
+    },
+  };
+}
+
+module.exports = { issueCertificate };

--- a/backend/harjoot/usecases/precheckCertificate.js
+++ b/backend/harjoot/usecases/precheckCertificate.js
@@ -1,0 +1,91 @@
+// backend/harjoot/usecases/precheckCertificate.js
+//
+// DS Section 4 — precheck before /issue. The frontend calls this BEFORE
+// asking the educator to sign the HACK transfer transaction. Three things
+// are answered atomically:
+//   1) Is the educator allowed to issue right now? (approval status)
+//   2) Does the talent wallet already belong to a registered student?
+//      If not, the UI should fall back to Section 5 (invite flow).
+//   3) What is the exact HACK amount + on-chain addresses the issuer
+//      must use for the payment? (paymentService.calculateMintPrice)
+//
+// Returns a Result-style object; throws ONLY on programmer errors.
+
+const LOG_PREFIX = "[precheckCertificate]";
+
+const WALLET_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * @param {object} params
+ * @param {object} params.models          db (db.User).
+ * @param {object} params.paymentService  Must expose calculateMintPrice().
+ * @param {object} params.educator        The authenticated issuer's User row.
+ * @param {string} params.studentWallet   Target talent wallet (any casing).
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   reason?: "EDUCATOR_NOT_APPROVED" | "TALENT_NOT_FOUND",
+ *   price?: {
+ *     amountHack: bigint,
+ *     amountHackString: string,
+ *     userPriceUsdCents: number,
+ *     treasuryAddress: string,
+ *     hackTokenAddress: string,
+ *   },
+ *   talent?: { id: number, walletAddress: string },
+ * }>}
+ */
+async function precheckCertificate({ models, paymentService, educator, studentWallet }) {
+  if (!models || !models.User || !paymentService || typeof paymentService.calculateMintPrice !== "function") {
+    throw new TypeError(
+      "precheckCertificate requires { models.User, paymentService.calculateMintPrice, educator, studentWallet }",
+    );
+  }
+  if (!educator || typeof educator !== "object") {
+    throw new TypeError("precheckCertificate requires an educator User row");
+  }
+  if (typeof studentWallet !== "string" || !WALLET_REGEX.test(studentWallet)) {
+    throw new TypeError("precheckCertificate requires a valid 0x-prefixed wallet address");
+  }
+
+  // (1) Educator approval gate. Section 2.5 sets this on register/approve.
+  if (educator.educator_approval_status !== "approved") {
+    console.warn(
+      `${LOG_PREFIX} educator_id=${educator.id} blocked status=${educator.educator_approval_status}`,
+    );
+    return { ok: false, reason: "EDUCATOR_NOT_APPROVED" };
+  }
+
+  const normalizedWallet = studentWallet.toLowerCase();
+
+  // (2) Talent must exist as a registered student. Equality + role check in
+  // one query — a recruiter or issuer accidentally given this wallet must
+  // NOT pass as a valid talent.
+  const talent = await models.User.findOne({
+    where: { wallet_address: normalizedWallet, role: "student" },
+    attributes: ["id", "wallet_address"],
+  });
+  if (!talent) {
+    return { ok: false, reason: "TALENT_NOT_FOUND" };
+  }
+
+  // (3) Pricing. calculateMintPrice() is pure and may throw on a misconfigured
+  // env — we let that propagate as a 500 because it's a programmer/config
+  // error, not a user-correctable state.
+  const price = paymentService.calculateMintPrice();
+
+  return {
+    ok: true,
+    price: {
+      amountHack: price.amountHack,
+      // bigint does not survive JSON.stringify. Provide a decimal string so the
+      // route handler can serialize it directly into the response body.
+      amountHackString: price.amountHack.toString(),
+      userPriceUsdCents: price.userPriceUsdCents,
+      treasuryAddress: price.treasuryAddress,
+      hackTokenAddress: price.hackTokenAddress,
+    },
+    talent: { id: talent.id, walletAddress: talent.wallet_address },
+  };
+}
+
+module.exports = { precheckCertificate };

--- a/backend/harjoot/usecases/rejectEducator.js
+++ b/backend/harjoot/usecases/rejectEducator.js
@@ -1,0 +1,81 @@
+// backend/harjoot/usecases/rejectEducator.js
+//
+// DS Section 2.5 — reject a pending educator. Stores the reason on the user
+// row and triggers the notification email. The educator can re-apply by
+// having an admin call approveEducator later (which clears rejection_reason).
+//
+// Returns a Result-style object; throws ONLY on programmer errors (missing
+// deps, invalid args including a blank reason).
+
+const LOG_PREFIX = "[rejectEducator]";
+
+/**
+ * Reject a pending educator account with a reason.
+ *
+ * @param {object} params
+ * @param {object} params.models        The Sequelize `db` object (db.User).
+ * @param {object} params.emailService  Must expose notifyEducatorRejected.
+ * @param {number} params.userId        Target educator's user id.
+ * @param {number} params.adminId       Admin user id (recorded for the log).
+ * @param {string} params.reason        Required non-empty reason.
+ * @returns {Promise<{
+ *   ok: boolean,
+ *   reason?: "USER_NOT_FOUND" | "NOT_AN_ISSUER",
+ *   user?: { id: number, status: "rejected", rejection_reason: string },
+ * }>}
+ */
+async function rejectEducator({ models, emailService, userId, adminId, reason }) {
+  if (!models || !models.User || !emailService) {
+    throw new TypeError(
+      "rejectEducator requires { models.User, emailService, userId, adminId, reason }",
+    );
+  }
+  if (userId === undefined || userId === null) {
+    throw new TypeError("rejectEducator requires a userId");
+  }
+  if (typeof reason !== "string" || !reason.trim()) {
+    throw new TypeError("rejectEducator requires a non-empty reason string");
+  }
+
+  const trimmedReason = reason.trim();
+
+  const user = await models.User.findByPk(userId);
+  if (!user) {
+    return { ok: false, reason: "USER_NOT_FOUND" };
+  }
+  if (user.role !== "issuer") {
+    return { ok: false, reason: "NOT_AN_ISSUER" };
+  }
+
+  await user.update({
+    educator_approval_status: "rejected",
+    rejection_reason: trimmedReason,
+    approved_at: null,
+    approved_by: null,
+  });
+
+  // Email side effect — never undo the DB rejection on email failure.
+  try {
+    if (user.email) {
+      await emailService.notifyEducatorRejected({
+        to: user.email,
+        name: user.name,
+        reason: trimmedReason,
+      });
+    } else {
+      console.warn(`${LOG_PREFIX} no email on file for user_id=${userId}; skipped notification`);
+    }
+  } catch (err) {
+    console.error(
+      `${LOG_PREFIX} email notification failed user_id=${userId}: ${err.name || "Error"}: ${err.message}`,
+    );
+  }
+
+  console.log(`${LOG_PREFIX} rejected user_id=${userId} by admin_id=${adminId} reason="${trimmedReason}"`);
+  return {
+    ok: true,
+    user: { id: user.id, status: "rejected", rejection_reason: trimmedReason },
+  };
+}
+
+module.exports = { rejectEducator };

--- a/backend/index.js
+++ b/backend/index.js
@@ -142,6 +142,35 @@ app.get("/health", async (req, res) => {
   }
 });
 
+// Reports the most recent state from the Harjoot partner-health check
+// (runs at startup; non-blocking). Used by external monitors to alert
+// when the partner integration has degraded WITHOUT having to retry the
+// upstream call themselves. Response shape:
+//   { ok, hasCache, lastCheckedAt, lastError, partner: { name?, status? } }
+// Sensitive partner fields (api keys, internal ids) are NOT echoed.
+app.get("/health/harjoot", (req, res) => {
+  try {
+    const { getHealthState, getCachedPartnerInfo } =
+      require("./harjoot/usecases/checkPartnerHealth");
+    const state = getHealthState();
+    const cached = getCachedPartnerInfo();
+    // Echo only a curated subset of the cached partner payload.
+    const partner = cached
+      ? { name: cached.name || null, status: cached.status || null }
+      : null;
+    return res.json({
+      ok: state.hasCache && !state.lastError,
+      hasCache: state.hasCache,
+      lastCheckedAt: state.lastCheckedAt,
+      lastError: state.lastError,
+      partner,
+    });
+  } catch (err) {
+    console.error("Health check - Harjoot error:", err);
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
 // ---------- 404 ----------
 app.use((req, res, next) => {
   res.status(404).json({ error: "Not found" });

--- a/backend/index.js
+++ b/backend/index.js
@@ -38,6 +38,14 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
+// Correlation ID — accepts incoming X-Correlation-ID or generates a fresh
+// req-<uuid>. Echoes on the response and runs the rest of the request
+// inside the AsyncLocalStorage context so downstream modules (Harjoot
+// client, use cases, the treasury worker) can read it without explicit
+// plumbing. See backend/middleware/correlationId.js.
+const correlationId = require("./middleware/correlationId");
+app.use(correlationId());
+
 // ---------- Global rate limiter ----------
 // Covers all /api/ routes. Specific limiters (login: 8/min, upload: 10/hr)
 // apply on top of this for their own endpoints.

--- a/backend/index.js
+++ b/backend/index.js
@@ -168,13 +168,14 @@ let server;
     console.log("Email verification columns ensured.");
 
     // ----------------------------------------------------------------------
-    // DS Section 0 — Harjoot partner health check (SKELETON / pending).
-    // On startup, confirm the Harjoot partner API key is valid and cache the
-    // partner config in memory:
-    //   const info = await require("./services/harjootService").getPartnerInfo();
-    // If the call fails, log it and alert ops — do NOT block server startup.
-    // See documents/harjoot-integration-handoff.md.
+    // DS Section 0 — Harjoot partner health check.
+    // Confirms the partner API key is valid and caches the partner config in
+    // memory. The use case never throws — Harjoot being unreachable must NOT
+    // block server startup. See backend/harjoot/usecases/checkPartnerHealth.js.
     // ----------------------------------------------------------------------
+    const { createHarjootClient } = require("./harjoot/client");
+    const { checkPartnerHealth } = require("./harjoot/usecases/checkPartnerHealth");
+    await checkPartnerHealth(createHarjootClient());
 
     server = app.listen(port, () => {
       console.log(`✅ Server running on port ${port}`);

--- a/backend/index.js
+++ b/backend/index.js
@@ -196,10 +196,13 @@ let server;
     });
 
 
-    // DS Section 13 — schedule the Treasury -> Harjoot settlement worker here
-    // once implemented (mirrors the session-purge cron above):
-    //   require("./workers/treasuryForwarder").scheduleTreasuryForwarder();
-    // See documents/harjoot-integration-handoff.md.
+    // DS Section 13 — async Treasury -> Harjoot settlement worker.
+    // Drains `treasury_transfers_queue` every 10 minutes. The launch
+    // strategy is `manual` (env: TREASURY_CONVERSION_MODE), which parks
+    // each batch as `awaiting_manual_conversion` for the CTO/ops to
+    // settle out of band — no on-chain action is taken automatically.
+    // See backend/workers/treasuryForwarder.js + harjoot/strategies/.
+    require("./workers/treasuryForwarder").scheduleTreasuryForwarder();
 
   } catch (err) {
     console.error("Failed to start server:", err);

--- a/backend/lib/__tests__/correlationContext.test.js
+++ b/backend/lib/__tests__/correlationContext.test.js
@@ -1,0 +1,51 @@
+// backend/lib/__tests__/correlationContext.test.js
+
+const { runWithCorrelationId, getCorrelationId } = require("../correlationContext");
+
+describe("correlationContext", () => {
+  test("getCorrelationId returns undefined outside of any run", () => {
+    expect(getCorrelationId()).toBeUndefined();
+  });
+
+  test("runWithCorrelationId exposes the id to synchronous descendants", () => {
+    runWithCorrelationId("req-abc", () => {
+      expect(getCorrelationId()).toBe("req-abc");
+    });
+    // And leaves no leakage after the function returns.
+    expect(getCorrelationId()).toBeUndefined();
+  });
+
+  test("id survives across awaited async boundaries", async () => {
+    await runWithCorrelationId("req-xyz", async () => {
+      await Promise.resolve();
+      await new Promise((r) => setImmediate(r));
+      expect(getCorrelationId()).toBe("req-xyz");
+    });
+  });
+
+  test("nested runs shadow the outer id, then restore it", () => {
+    runWithCorrelationId("outer", () => {
+      expect(getCorrelationId()).toBe("outer");
+      runWithCorrelationId("inner", () => {
+        expect(getCorrelationId()).toBe("inner");
+      });
+      expect(getCorrelationId()).toBe("outer");
+    });
+  });
+
+  test("rejects empty / non-string ids", () => {
+    expect(() => runWithCorrelationId("", () => {})).toThrow(TypeError);
+    expect(() => runWithCorrelationId(undefined, () => {})).toThrow(TypeError);
+    expect(() => runWithCorrelationId(123, () => {})).toThrow(TypeError);
+  });
+
+  test("rejects a missing fn", () => {
+    expect(() => runWithCorrelationId("ok")).toThrow(TypeError);
+    expect(() => runWithCorrelationId("ok", "not-a-fn")).toThrow(TypeError);
+  });
+
+  test("returns the fn's return value", () => {
+    const ret = runWithCorrelationId("x", () => 42);
+    expect(ret).toBe(42);
+  });
+});

--- a/backend/lib/__tests__/dbLock.test.js
+++ b/backend/lib/__tests__/dbLock.test.js
@@ -1,0 +1,162 @@
+// backend/lib/__tests__/dbLock.test.js
+//
+// Postgres advisory-lock helper. We don't spin up a real Postgres for
+// these tests; instead we use a sequelize-shaped double that records
+// the SQL queries and returns canned results.
+
+const {
+  withPgAdvisoryLock,
+  LOCK_KEYS,
+  __getDialect,
+} = require("../dbLock");
+
+function makeFakeSequelize({ dialect = "postgres", tryAcquireResult = true, queryError = null } = {}) {
+  const calls = [];
+  const sequelize = {
+    getDialect: () => dialect,
+    query: jest.fn().mockImplementation(async (sql, opts) => {
+      calls.push({ sql, opts });
+      if (queryError) throw queryError;
+      if (sql.includes("pg_try_advisory_lock")) {
+        return [[{ acquired: tryAcquireResult }], {}];
+      }
+      if (sql.includes("pg_advisory_unlock")) {
+        return [[{ pg_advisory_unlock: true }], {}];
+      }
+      return [[], {}];
+    }),
+  };
+  return { sequelize, calls };
+}
+
+beforeAll(() => {
+  jest.spyOn(console, "log").mockImplementation(() => {});
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+afterAll(() => jest.restoreAllMocks());
+
+describe("LOCK_KEYS", () => {
+  test("exposes TREASURY_FORWARDER as a bigint", () => {
+    expect(typeof LOCK_KEYS.TREASURY_FORWARDER).toBe("bigint");
+  });
+
+  test("is frozen so two callers cannot collide by mutation", () => {
+    expect(Object.isFrozen(LOCK_KEYS)).toBe(true);
+  });
+});
+
+describe("__getDialect", () => {
+  test("reads from sequelize.getDialect() when available", () => {
+    expect(__getDialect({ getDialect: () => "postgres" })).toBe("postgres");
+  });
+  test("falls back to options.dialect for older Sequelize", () => {
+    expect(__getDialect({ options: { dialect: "sqlite" } })).toBe("sqlite");
+  });
+  test("returns null for missing sequelize", () => {
+    expect(__getDialect(null)).toBeNull();
+  });
+});
+
+describe("withPgAdvisoryLock — Postgres dialect", () => {
+  test("acquires lock, runs fn, releases lock — returns fn's value", async () => {
+    const { sequelize, calls } = makeFakeSequelize({ tryAcquireResult: true });
+    const fn = jest.fn().mockResolvedValue("ok-result");
+
+    const result = await withPgAdvisoryLock(
+      sequelize, LOCK_KEYS.TREASURY_FORWARDER, fn,
+    );
+
+    expect(result).toBe("ok-result");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(calls.length).toBe(2);
+    expect(calls[0].sql).toMatch(/pg_try_advisory_lock/);
+    expect(calls[1].sql).toMatch(/pg_advisory_unlock/);
+  });
+
+  test("releases the lock even when fn throws", async () => {
+    const { sequelize, calls } = makeFakeSequelize({ tryAcquireResult: true });
+    const fn = jest.fn().mockRejectedValue(new Error("boom"));
+
+    await expect(
+      withPgAdvisoryLock(sequelize, LOCK_KEYS.TREASURY_FORWARDER, fn),
+    ).rejects.toThrow("boom");
+
+    expect(calls[calls.length - 1].sql).toMatch(/pg_advisory_unlock/);
+  });
+
+  test("skipped when pg_try_advisory_lock returns false (another instance holds it)", async () => {
+    const { sequelize, calls } = makeFakeSequelize({ tryAcquireResult: false });
+    const fn = jest.fn();
+    const onSkip = jest.fn();
+
+    const result = await withPgAdvisoryLock(
+      sequelize, LOCK_KEYS.TREASURY_FORWARDER, fn, { onSkip },
+    );
+
+    expect(result).toEqual({ skipped: true });
+    expect(fn).not.toHaveBeenCalled();
+    expect(onSkip).toHaveBeenCalledTimes(1);
+    // No unlock call when we never acquired.
+    expect(calls.some((c) => c.sql.includes("pg_advisory_unlock"))).toBe(false);
+  });
+
+  test("fail-closed: if tryAdvisoryLock throws, fn is NOT run and onSkip fires", async () => {
+    const { sequelize } = makeFakeSequelize({
+      queryError: new Error("connection lost"),
+    });
+    const fn = jest.fn();
+    const onSkip = jest.fn();
+
+    const result = await withPgAdvisoryLock(
+      sequelize, LOCK_KEYS.TREASURY_FORWARDER, fn, { onSkip },
+    );
+
+    expect(result).toEqual({ skipped: true });
+    expect(fn).not.toHaveBeenCalled();
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("withPgAdvisoryLock — non-Postgres dialect (SQLite tests)", () => {
+  test("runs fn directly without attempting any lock SQL", async () => {
+    const { sequelize, calls } = makeFakeSequelize({ dialect: "sqlite" });
+    const fn = jest.fn().mockResolvedValue(42);
+
+    const result = await withPgAdvisoryLock(
+      sequelize, LOCK_KEYS.TREASURY_FORWARDER, fn,
+    );
+
+    expect(result).toBe(42);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(calls.length).toBe(0); // no SQL issued
+  });
+
+  test("works for mysql / mariadb too (any non-postgres)", async () => {
+    const { sequelize } = makeFakeSequelize({ dialect: "mysql" });
+    const fn = jest.fn().mockResolvedValue("ok");
+    await expect(
+      withPgAdvisoryLock(sequelize, LOCK_KEYS.TREASURY_FORWARDER, fn),
+    ).resolves.toBe("ok");
+  });
+});
+
+describe("withPgAdvisoryLock — programmer-error guards", () => {
+  test("throws TypeError when sequelize is missing", async () => {
+    await expect(
+      withPgAdvisoryLock(null, LOCK_KEYS.TREASURY_FORWARDER, () => {}),
+    ).rejects.toThrow(TypeError);
+  });
+  test("throws TypeError when fn is not a function", async () => {
+    const { sequelize } = makeFakeSequelize();
+    await expect(
+      withPgAdvisoryLock(sequelize, LOCK_KEYS.TREASURY_FORWARDER, "not-a-fn"),
+    ).rejects.toThrow(TypeError);
+  });
+  test("throws TypeError when key is not bigint", async () => {
+    const { sequelize } = makeFakeSequelize();
+    await expect(
+      withPgAdvisoryLock(sequelize, 42, () => {}),
+    ).rejects.toThrow(TypeError);
+  });
+});

--- a/backend/lib/__tests__/rateLimitStore.test.js
+++ b/backend/lib/__tests__/rateLimitStore.test.js
@@ -1,0 +1,68 @@
+// backend/lib/__tests__/rateLimitStore.test.js
+
+const buildRateLimitStore = require("../rateLimitStore");
+
+const ORIGINAL_ENV = { ...process.env };
+
+let warnSpy;
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.REDIS_URL;
+  jest.resetModules();
+  buildRateLimitStore.__resetWarnings();
+  warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("buildRateLimitStore", () => {
+  test("returns undefined when REDIS_URL is unset (MemoryStore fallback)", () => {
+    const store = buildRateLimitStore("limiter-a");
+    expect(store).toBeUndefined();
+  });
+
+  test("warns ONCE per limiter name when falling back to memory", () => {
+    buildRateLimitStore("limiter-a");
+    buildRateLimitStore("limiter-a"); // second call same name
+    buildRateLimitStore("limiter-b"); // different name -> separate warn
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    const messages = warnSpy.mock.calls.map(([m]) => m);
+    expect(messages.some((m) => m.includes("limiter-a"))).toBe(true);
+    expect(messages.some((m) => m.includes("limiter-b"))).toBe(true);
+  });
+
+  test("__resetWarnings restores the warn channel", () => {
+    buildRateLimitStore("limiter-x");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    buildRateLimitStore.__resetWarnings();
+    buildRateLimitStore("limiter-x");
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns a RedisStore-shaped object when REDIS_URL is set", () => {
+    // Mock the redis service so the lazy require doesn't try to connect.
+    jest.doMock("../../services/redis", () => ({
+      getRedis: () => ({
+        call: jest.fn().mockResolvedValue("OK"),
+      }),
+    }));
+    process.env.REDIS_URL = "redis://localhost:6379";
+
+    // Re-require to pick up the mock + the env override.
+    jest.resetModules();
+    const freshBuild = require("../rateLimitStore");
+
+    const store = freshBuild("limiter-real");
+    expect(store).toBeDefined();
+    // express-rate-limit stores expose increment / decrement / resetKey /
+    // resetAll. We just sanity-check that one of these exists rather than
+    // trying to assert on instanceof (RedisStore is an ESM class in v4+).
+    expect(typeof store.increment).toBe("function");
+    expect(typeof store.resetKey).toBe("function");
+    expect(warnSpy).not.toHaveBeenCalled(); // Redis path warns nothing
+  });
+});

--- a/backend/lib/correlationContext.js
+++ b/backend/lib/correlationContext.js
@@ -1,0 +1,55 @@
+// backend/lib/correlationContext.js
+//
+// AsyncLocalStorage-backed correlation context. Lets any code in the
+// async chain (use cases, services, the Harjoot http client, the cron
+// worker) read the current correlation ID WITHOUT threading it through
+// every function signature.
+//
+// Usage:
+//   In a request middleware:
+//     runWithCorrelationId(req.correlationId, () => next());
+//   Or in the worker tick:
+//     await runWithCorrelationId(`cron-${uuid()}`, async () => { ... });
+//
+// Anywhere downstream:
+//     const id = getCorrelationId();   // string or undefined
+//
+// This is intentionally vanilla Node — no external dep — because
+// AsyncLocalStorage is the right primitive for exactly this problem.
+
+const { AsyncLocalStorage } = require("async_hooks");
+
+const storage = new AsyncLocalStorage();
+
+/**
+ * Run `fn` with the given correlation ID active in the async context.
+ *
+ * @template T
+ * @param {string} correlationId
+ * @param {() => T} fn
+ * @returns {T}
+ */
+function runWithCorrelationId(correlationId, fn) {
+  if (typeof correlationId !== "string" || !correlationId) {
+    throw new TypeError("runWithCorrelationId requires a non-empty correlationId");
+  }
+  if (typeof fn !== "function") {
+    throw new TypeError("runWithCorrelationId requires a function");
+  }
+  return storage.run({ correlationId }, fn);
+}
+
+/**
+ * @returns {string | undefined}
+ */
+function getCorrelationId() {
+  const store = storage.getStore();
+  return store && store.correlationId;
+}
+
+module.exports = {
+  runWithCorrelationId,
+  getCorrelationId,
+  // Exposed for tests asserting on the underlying storage.
+  __storage: storage,
+};

--- a/backend/lib/dbLock.js
+++ b/backend/lib/dbLock.js
@@ -1,0 +1,126 @@
+// backend/lib/dbLock.js
+//
+// Cross-instance locking via Postgres advisory locks. Used by the treasury
+// worker so two boxes running the same cron don't both fetch the same
+// pending rows and (in non-manual conversion modes) double-spend USDT.
+//
+// SQLite (used by the test suite) does NOT support advisory locks. When
+// the dialect isn't Postgres we no-op and execute `fn` directly — tests
+// are single-instance so the lock is unnecessary, and skipping it keeps
+// the helper portable.
+//
+// Lock-key contract:
+//   Use a stable bigint per logical "section" (e.g. one for the treasury
+//   worker, another for some hypothetical reconciliation job). Define
+//   them as named constants below so collisions are detected at code
+//   review time, not at runtime.
+//
+// Usage:
+//   const { withPgAdvisoryLock, LOCK_KEYS } = require("../lib/dbLock");
+//   const result = await withPgAdvisoryLock(
+//     sequelize,
+//     LOCK_KEYS.TREASURY_FORWARDER,
+//     async () => { ...do work... },
+//     { onSkip: () => console.log("another instance has the lock") },
+//   );
+//   // result is either fn()'s return value, or { skipped: true } if the
+//   // lock was held by another instance.
+
+const LOG_PREFIX = "[dbLock]";
+
+// Postgres advisory-lock keys must fit in a signed 8-byte int. Picking
+// values from a fixed namespace (HKCN-... in ASCII codepoints) so collisions
+// with other apps sharing the same DB are extremely unlikely.
+const LOCK_KEYS = Object.freeze({
+  TREASURY_FORWARDER: 0x48414b43_5452_5357n, // "HACKTRSW" — TReasury SWorker
+});
+
+function getDialect(sequelize) {
+  if (!sequelize) return null;
+  if (typeof sequelize.getDialect === "function") return sequelize.getDialect();
+  // Older Sequelize used `options.dialect`.
+  return sequelize.options && sequelize.options.dialect;
+}
+
+/**
+ * Try to acquire `key` via pg_try_advisory_lock. Returns true if acquired.
+ * Non-blocking: if another session holds the lock, returns false immediately.
+ *
+ * @param {import("sequelize").Sequelize} sequelize
+ * @param {bigint} key
+ */
+async function tryAdvisoryLock(sequelize, key) {
+  const [rows] = await sequelize.query(
+    "SELECT pg_try_advisory_lock(CAST(:key AS bigint)) AS acquired",
+    { replacements: { key: String(key) } },
+  );
+  return rows && rows[0] && rows[0].acquired === true;
+}
+
+async function releaseAdvisoryLock(sequelize, key) {
+  try {
+    await sequelize.query(
+      "SELECT pg_advisory_unlock(CAST(:key AS bigint))",
+      { replacements: { key: String(key) } },
+    );
+  } catch (err) {
+    // Releasing a lock we don't hold is harmless in Postgres (returns
+    // false) but the query itself might fail under connection loss.
+    // Log and continue — the connection will release its locks on close.
+    console.warn(`${LOG_PREFIX} release failed for key=${key}: ${err.message || err}`);
+  }
+}
+
+/**
+ * Run `fn` while holding a Postgres advisory lock. On non-Postgres dialects
+ * (SQLite in tests) the lock is skipped and `fn` runs unconditionally.
+ *
+ * @template T
+ * @param {import("sequelize").Sequelize} sequelize
+ * @param {bigint} key
+ * @param {() => Promise<T>} fn
+ * @param {{ onSkip?: () => void }} [opts]
+ * @returns {Promise<T | { skipped: true }>}
+ */
+async function withPgAdvisoryLock(sequelize, key, fn, opts = {}) {
+  if (!sequelize) throw new TypeError("withPgAdvisoryLock requires a sequelize instance");
+  if (typeof fn !== "function") throw new TypeError("withPgAdvisoryLock requires an async fn");
+  if (typeof key !== "bigint") throw new TypeError("withPgAdvisoryLock requires a bigint key");
+
+  const dialect = getDialect(sequelize);
+  if (dialect !== "postgres") {
+    // SQLite / mariadb / etc — no advisory locks, just run.
+    return fn();
+  }
+
+  let acquired = false;
+  try {
+    acquired = await tryAdvisoryLock(sequelize, key);
+  } catch (err) {
+    // If we can't even attempt the lock, fail closed — better to skip a
+    // tick than to run unsafely.
+    console.error(`${LOG_PREFIX} tryAdvisoryLock failed: ${err.message || err}`);
+    if (opts.onSkip) opts.onSkip();
+    return { skipped: true };
+  }
+
+  if (!acquired) {
+    if (opts.onSkip) opts.onSkip();
+    return { skipped: true };
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await releaseAdvisoryLock(sequelize, key);
+  }
+}
+
+module.exports = {
+  withPgAdvisoryLock,
+  LOCK_KEYS,
+  // Exposed for tests so they can verify the contract directly.
+  __tryAdvisoryLock: tryAdvisoryLock,
+  __releaseAdvisoryLock: releaseAdvisoryLock,
+  __getDialect: getDialect,
+};

--- a/backend/lib/rateLimitStore.js
+++ b/backend/lib/rateLimitStore.js
@@ -1,0 +1,66 @@
+// backend/lib/rateLimitStore.js
+//
+// Shared helper for express-rate-limit stores.
+//
+// In production (REDIS_URL set) every per-route limiter should share state
+// with every other instance of the process — otherwise the limit is
+// effectively N × max for N instances behind a load balancer, which is
+// what a security review caught.
+//
+// In tests / local dev (no REDIS_URL) we fall back to the default
+// in-memory store; the suite must not require Redis to boot.
+//
+// Usage:
+//   const buildRateLimitStore = require("../lib/rateLimitStore");
+//   const limiter = rateLimit({
+//     windowMs: ...,
+//     max: ...,
+//     store: buildRateLimitStore("/issue"),
+//   });
+//
+// `name` is a human label that ends up in the warn log when Redis is
+// unavailable, so ops can tell WHICH limiter is degraded.
+
+const LOG_PREFIX = "[rateLimitStore]";
+
+// Cache the warn so we don't spam the log once per limiter at boot.
+const warnedFor = new Set();
+
+/**
+ * @param {string} name  Human label for warn logs.
+ * @returns {import("rate-limit-redis").RedisStore | undefined}
+ *          When undefined, express-rate-limit uses its default MemoryStore.
+ */
+function buildRateLimitStore(name = "anonymous") {
+  if (!process.env.REDIS_URL) {
+    if (!warnedFor.has(name)) {
+      warnedFor.add(name);
+      console.warn(
+        `${LOG_PREFIX} REDIS_URL not set — limiter "${name}" falls back to ` +
+          "in-memory store (per-process). Multi-instance deployments will see " +
+          "effective_max = max × instance_count. Set REDIS_URL to share state.",
+      );
+    }
+    return undefined;
+  }
+
+  // Require lazily — `rate-limit-redis` and `ioredis` are heavy imports we
+  // shouldn't pay for unless someone actually wires a limiter.
+  const { RedisStore } = require("rate-limit-redis");
+  const { getRedis } = require("../services/redis");
+
+  return new RedisStore({
+    sendCommand: (...args) => getRedis().call(...args),
+  });
+}
+
+/**
+ * Test-only — clear the warned-for set so a test toggling REDIS_URL can
+ * observe the warn fresh.
+ */
+function __resetWarnings() {
+  warnedFor.clear();
+}
+
+module.exports = buildRateLimitStore;
+module.exports.__resetWarnings = __resetWarnings;

--- a/backend/middleware/__tests__/correlationId.test.js
+++ b/backend/middleware/__tests__/correlationId.test.js
@@ -1,0 +1,72 @@
+// backend/middleware/__tests__/correlationId.test.js
+//
+// Lightweight test that builds a tiny Express app, hits it with supertest,
+// and asserts on the response header + on what the downstream handler saw
+// via getCorrelationId().
+
+const express = require("express");
+const request = require("supertest");
+
+const correlationId = require("../correlationId");
+const { getCorrelationId } = require("../../lib/correlationContext");
+
+function buildApp() {
+  const app = express();
+  app.use(correlationId());
+  app.get("/echo", (req, res) => {
+    res.json({
+      reqProperty: req.correlationId,
+      // Read via the context to prove the storage was actually populated.
+      contextRead: getCorrelationId(),
+    });
+  });
+  return app;
+}
+
+describe("correlationId middleware", () => {
+  test("generates a req-<uuid> when no header is sent and echoes it on the response", async () => {
+    const res = await request(buildApp()).get("/echo");
+    expect(res.status).toBe(200);
+    expect(res.headers["x-correlation-id"]).toMatch(/^req-[0-9a-f-]{36}$/);
+    expect(res.body.reqProperty).toBe(res.headers["x-correlation-id"]);
+    expect(res.body.contextRead).toBe(res.headers["x-correlation-id"]);
+  });
+
+  test("honors a well-formed incoming X-Correlation-ID", async () => {
+    const res = await request(buildApp())
+      .get("/echo")
+      .set("X-Correlation-ID", "trace-abc.123_:09");
+    expect(res.headers["x-correlation-id"]).toBe("trace-abc.123_:09");
+    expect(res.body.reqProperty).toBe("trace-abc.123_:09");
+  });
+
+  test("rejects an incoming header containing control chars and generates a fresh id instead", async () => {
+    const res = await request(buildApp())
+      .get("/echo")
+      // Supertest strips control chars too aggressively; use a value with a
+      // banned punctuation char like a space.
+      .set("X-Correlation-ID", "bad value with space");
+    expect(res.headers["x-correlation-id"]).toMatch(/^req-[0-9a-f-]{36}$/);
+    expect(res.headers["x-correlation-id"]).not.toBe("bad value with space");
+  });
+
+  test("rejects an oversize incoming header (>128 chars) and generates a fresh id", async () => {
+    const giant = "a".repeat(200);
+    const res = await request(buildApp())
+      .get("/echo")
+      .set("X-Correlation-ID", giant);
+    expect(res.headers["x-correlation-id"]).toMatch(/^req-[0-9a-f-]{36}$/);
+  });
+
+  test("each request gets its own id", async () => {
+    const app = buildApp();
+    const a = await request(app).get("/echo");
+    const b = await request(app).get("/echo");
+    expect(a.headers["x-correlation-id"]).not.toBe(b.headers["x-correlation-id"]);
+  });
+
+  test("getCorrelationId is undefined outside of a request (no leaked context)", async () => {
+    await request(buildApp()).get("/echo");
+    expect(getCorrelationId()).toBeUndefined();
+  });
+});

--- a/backend/middleware/correlationId.js
+++ b/backend/middleware/correlationId.js
@@ -1,0 +1,57 @@
+// backend/middleware/correlationId.js
+//
+// Express middleware. Accepts an incoming X-Correlation-ID header (from a
+// frontend / load balancer / upstream service) when present and well-formed,
+// otherwise generates one. Echoes it back on the response so the caller can
+// quote it in a bug report, AND runs the rest of the request inside the
+// correlation context so any downstream module (use cases, harjoot client,
+// etc.) can read it via getCorrelationId().
+//
+// Mount BEFORE the routes:
+//   const correlationId = require("./middleware/correlationId");
+//   app.use(correlationId());
+
+const crypto = require("crypto");
+const { runWithCorrelationId } = require("../lib/correlationContext");
+
+const HEADER = "x-correlation-id";
+const MAX_LEN = 128;
+// Allow ASCII alphanumerics + a few punctuation characters; reject control
+// chars and anything that could break log parsers or be log-injected.
+const VALID_INCOMING = /^[A-Za-z0-9._:-]{1,128}$/;
+
+function generate() {
+  // crypto.randomUUID() is RFC 4122 v4. Prefix tags this as a request-origin
+  // ID (the worker uses `cron-...`) so a glance at logs tells you which
+  // surface produced it.
+  return `req-${crypto.randomUUID()}`;
+}
+
+/**
+ * @param {object} [opts]
+ * @param {string} [opts.header]   Override header name (defaults to x-correlation-id).
+ * @returns {import("express").RequestHandler}
+ */
+function correlationIdMiddleware(opts = {}) {
+  const headerName = (opts.header || HEADER).toLowerCase();
+  return function correlationId(req, res, next) {
+    const incoming = req.headers[headerName];
+    let correlationId;
+    if (typeof incoming === "string" && VALID_INCOMING.test(incoming)) {
+      correlationId = incoming;
+    } else {
+      correlationId = generate();
+    }
+    // Attach to both req (for explicit access in handlers) and the response
+    // header (so the caller can correlate their own logs).
+    req.correlationId = correlationId;
+    res.setHeader("X-Correlation-ID", correlationId);
+    // Defensive: never let an unbounded incoming value pass through.
+    if (correlationId.length > MAX_LEN) correlationId = correlationId.slice(0, MAX_LEN);
+    runWithCorrelationId(correlationId, () => next());
+  };
+}
+
+module.exports = correlationIdMiddleware;
+module.exports.__generate = generate;
+module.exports.__HEADER = HEADER;

--- a/backend/middleware/harjootAccess.js
+++ b/backend/middleware/harjootAccess.js
@@ -1,36 +1,103 @@
 // backend/middleware/harjootAccess.js
 //
-// SKELETON — Harjoot membership guard.
-// Implementation pending. See documents/harjoot-integration-handoff.md.
+// DS Section 3 — Express middleware that guards protected routes by ensuring
+// the authenticated user still has an active Harjoot membership.
 //
-// DS Section 3. Runs before protected routes (issuance, portfolio, search).
-// Reads users.harjoot_membership_expires_at; if missing or expired it calls
-// harjootService.checkAccess and, in the free-test phase, re-activates the
-// membership for free via harjootService.activateAccess.
+// Strategy:
+//   - Module-scope in-memory cache (5 minute TTL per userId) avoids hitting
+//     the DB on every request once we have confirmed an active membership.
+//   - On a cache miss, defers to the ensureMembership use case which reads
+//     the User row, talks to Harjoot only when the local expiry is stale,
+//     and persists any refreshed expiry. The use case never throws — Harjoot
+//     outages are soft-failed and the request is allowed through (DS decision:
+//     issuance has its own $HACK cost gate, so the membership middleware does
+//     not need to be a hard wall).
 //
-// SKELETON BEHAVIOUR: this middleware is currently a PASS-THROUGH. It does NOT
-// enforce membership yet — it only logs a warning. Do not rely on it for
-// access control until implemented.
+// Place this AFTER `authenticate` in the middleware chain so req.auth is set.
 
-// const harjootService = require("../services/harjootService");
+const db = require("../models");
+const { createHarjootClient } = require("../harjoot/client");
+const { ensureMembership } = require("../harjoot/usecases/ensureMembership");
+
+const LOG_PREFIX = "[harjootAccess]";
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+// Map<userId, { expiresAt: string|null, cachedAt: number }>
+const cache = new Map();
+
+// Lazy singleton — the client is cheap to build but config validation runs at
+// require time. Deferring until first request keeps the module load light and
+// matches how `index.js` instantiates the client for Section 0.
+let sharedClient = null;
+function getClient() {
+  if (!sharedClient) {
+    sharedClient = createHarjootClient();
+  }
+  return sharedClient;
+}
+
+function isCacheValid(entry, now) {
+  if (!entry) return false;
+  if (now - entry.cachedAt >= CACHE_TTL_MS) return false;
+  if (entry.expiresAt) {
+    const expiryMs = new Date(entry.expiresAt).getTime();
+    if (Number.isFinite(expiryMs) && expiryMs <= now) return false;
+  }
+  return true;
+}
 
 /**
- * Express middleware — require an active Harjoot membership for the caller.
+ * Express middleware — ensures the authenticated user has an active Harjoot
+ * membership. ALWAYS calls next() — failures are non-blocking.
  *
  * @param {import('express').Request}      req
  * @param {import('express').Response}     res
  * @param {import('express').NextFunction} next
  */
-function requireHarjootAccess(req, res, next) {
-  // TODO(impl): DS Section 3.
-  //  1. Read users.harjoot_membership_expires_at for req.auth.wallet.
-  //  2. If still valid -> next().
-  //  3. If missing or expired -> harjootService.checkAccess(); if inactive,
-  //     harjootService.activateAccess() (free re-activation in the test phase);
-  //     persist the new expiry; then next().
-  //  Suggested cache: 5 minutes per (wallet, segment).
-  console.warn("[harjootAccess] SKELETON pass-through — membership not enforced.");
+async function requireHarjootAccess(req, res, next) {
+  const userId = req.auth && req.auth.sub;
+  if (!userId) {
+    // The auth middleware should have already rejected this request. Defensive
+    // pass-through if it slipped through (downstream will re-check auth).
+    return next();
+  }
+
+  const now = Date.now();
+  const cached = cache.get(userId);
+  if (isCacheValid(cached, now)) {
+    return next();
+  }
+
+  try {
+    const result = await ensureMembership({
+      client: getClient(),
+      models: db,
+      userId,
+    });
+    if (result && result.ok) {
+      cache.set(userId, { expiresAt: result.expiresAt || null, cachedAt: now });
+    }
+  } catch (err) {
+    // Use case only throws on programmer errors (missing deps). Log loud — the
+    // request continues regardless so users are not locked out by a bug.
+    console.error(`${LOG_PREFIX} unexpected error: ${err && err.message}`);
+  }
+
   return next();
 }
 
-module.exports = { requireHarjootAccess };
+/**
+ * Test-only — clear the in-memory cache and force a new client on next use.
+ */
+function __resetForTests() {
+  cache.clear();
+  sharedClient = null;
+}
+
+module.exports = {
+  requireHarjootAccess,
+  __resetForTests,
+  // Exported so the middleware test can observe cache behaviour.
+  __cache: cache,
+  __CACHE_TTL_MS: CACHE_TTL_MS,
+};

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -9,12 +9,26 @@
 const express = require("express");
 const router = express.Router();
 const { body, param, validationResult } = require("express-validator");
+const { rateLimit, ipKeyGenerator } = require("express-rate-limit");
 
 const { authenticate } = require("../middleware/auth");
 const db = require("../models");
 const emailService = require("../services/emailService");
 const { approveEducator } = require("../harjoot/usecases/approveEducator");
 const { rejectEducator } = require("../harjoot/usecases/rejectEducator");
+
+// Per Phase 9 plan: 100/hour per admin wallet. Even with only one admin
+// today, a runaway script that loops over a list of educator IDs should be
+// throttled rather than smash the DB + email provider. Keyed by the
+// authenticated wallet; ipKeyGenerator is the IPv6-safe fallback.
+const adminEducatorLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many admin actions. Try again in an hour." },
+  keyGenerator: (req) => (req.auth && req.auth.wallet) || ipKeyGenerator(req),
+});
 
 // Guard — restrict a route to the configured admin wallet. Mirrors the
 // pattern used by routes/issuers.js POST /authorize.
@@ -52,6 +66,7 @@ router.post(
   "/educators/:userId/approve",
   authenticate,
   requireAdmin,
+  adminEducatorLimiter,
   [param("userId").isInt({ min: 1 }).withMessage("userId must be a positive integer")],
   async (req, res) => {
     if (handleValidation(req, res)) return;
@@ -87,6 +102,7 @@ router.post(
   "/educators/:userId/reject",
   authenticate,
   requireAdmin,
+  adminEducatorLimiter,
   [
     param("userId").isInt({ min: 1 }).withMessage("userId must be a positive integer"),
     body("reason")

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -1,26 +1,23 @@
 // backend/routes/admin.js
 //
-// SKELETON — HackChain admin routes.
-// Implementation pending. See documents/harjoot-integration-handoff.md.
+// HackChain admin routes — DS Section 2.5 educator approval workflow.
 //
-// DS Section 2.5 — educator approval workflow (manual whitelist).
-// After registering, an issuer is "pending_approval" and cannot issue
-// certificates until a HackChain admin approves them.
-//
-// ADMIN AUTH: this skeleton reuses the existing ADMIN_WALLET env-var pattern
-// (see routes/issuers.js POST /authorize). Whether HackChain needs a proper
-// admin role instead is an OPEN DECISION — see the handoff doc.
+// Auth model: reuses the ADMIN_WALLET env-var pattern from
+// routes/issuers.js POST /authorize. Whether HackChain needs a proper admin
+// role instead is an OPEN DECISION (see documents/harjoot-integration-handoff.md).
 
 const express = require("express");
 const router = express.Router();
+const { body, param, validationResult } = require("express-validator");
+
 const { authenticate } = require("../middleware/auth");
+const db = require("../models");
+const emailService = require("../services/emailService");
+const { approveEducator } = require("../harjoot/usecases/approveEducator");
+const { rejectEducator } = require("../harjoot/usecases/rejectEducator");
 
-const NOT_IMPLEMENTED = {
-  error: "Not implemented — see documents/harjoot-integration-handoff.md",
-};
-
-// Guard — restrict a route to the configured admin wallet.
-// Mirrors the pattern used by routes/issuers.js POST /authorize.
+// Guard — restrict a route to the configured admin wallet. Mirrors the
+// pattern used by routes/issuers.js POST /authorize.
 function requireAdmin(req, res, next) {
   const callerWallet = (req.auth && req.auth.wallet ? req.auth.wallet : "").toLowerCase();
   const adminWallet = (process.env.ADMIN_WALLET || "").toLowerCase();
@@ -30,31 +27,101 @@ function requireAdmin(req, res, next) {
   return next();
 }
 
+// Map a Result `reason` from the use cases to an HTTP status.
+const STATUS_BY_REASON = {
+  USER_NOT_FOUND: 404,
+  NOT_AN_ISSUER: 400,
+  ALREADY_APPROVED: 409,
+};
+
+function handleValidation(req, res) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    res.status(422).json({ errors: errors.array() });
+    return true;
+  }
+  return false;
+}
+
 /**
  * POST /api/admin/educators/:userId/approve
- * DS Section 2.5 — approve a pending educator.
- * Sets users.educator_approval_status = "approved" and emails the educator.
+ * DS Section 2.5 — approve a pending educator. Idempotent: a second call on
+ * an already-approved account returns 409.
  */
-router.post("/educators/:userId/approve", authenticate, requireAdmin, (req, res) => {
-  // TODO(impl): DS Section 2.5.
-  //  - UPDATE users SET educator_approval_status='approved', approved_at=now(),
-  //    approved_by=<adminId> WHERE id=:userId AND role='issuer'.
-  //  - emailService: notify the educator that the account was approved.
-  return res.status(501).json(NOT_IMPLEMENTED);
-});
+router.post(
+  "/educators/:userId/approve",
+  authenticate,
+  requireAdmin,
+  [param("userId").isInt({ min: 1 }).withMessage("userId must be a positive integer")],
+  async (req, res) => {
+    if (handleValidation(req, res)) return;
+
+    try {
+      const result = await approveEducator({
+        models: db,
+        emailService,
+        userId: parseInt(req.params.userId, 10),
+        adminId: req.auth.sub,
+      });
+
+      if (!result.ok) {
+        return res
+          .status(STATUS_BY_REASON[result.reason] || 400)
+          .json({ error: result.reason });
+      }
+
+      return res.json({ message: "Educator approved", user: result.user });
+    } catch (err) {
+      console.error("POST /api/admin/educators/:userId/approve error:", err);
+      return res.status(500).json({ error: "Failed to approve educator" });
+    }
+  },
+);
 
 /**
  * POST /api/admin/educators/:userId/reject
- * DS Section 2.5 — reject a pending educator. Body: { reason }.
- * Sets users.educator_approval_status = "rejected" and emails the educator.
+ * DS Section 2.5 — reject a pending educator. Requires a non-empty `reason`
+ * in the request body which is stored on the user row.
  */
-router.post("/educators/:userId/reject", authenticate, requireAdmin, (req, res) => {
-  // TODO(impl): DS Section 2.5.
-  //  - validate body.reason (non-empty string).
-  //  - UPDATE users SET educator_approval_status='rejected',
-  //    rejection_reason=:reason WHERE id=:userId AND role='issuer'.
-  //  - emailService: notify the educator of the rejection and the reason.
-  return res.status(501).json(NOT_IMPLEMENTED);
-});
+router.post(
+  "/educators/:userId/reject",
+  authenticate,
+  requireAdmin,
+  [
+    param("userId").isInt({ min: 1 }).withMessage("userId must be a positive integer"),
+    body("reason")
+      .isString()
+      .trim()
+      .notEmpty()
+      .withMessage("reason is required"),
+    body("reason")
+      .isLength({ max: 1000 })
+      .withMessage("reason must be 1000 characters or less"),
+  ],
+  async (req, res) => {
+    if (handleValidation(req, res)) return;
+
+    try {
+      const result = await rejectEducator({
+        models: db,
+        emailService,
+        userId: parseInt(req.params.userId, 10),
+        adminId: req.auth.sub,
+        reason: req.body.reason,
+      });
+
+      if (!result.ok) {
+        return res
+          .status(STATUS_BY_REASON[result.reason] || 400)
+          .json({ error: result.reason });
+      }
+
+      return res.json({ message: "Educator rejected", user: result.user });
+    } catch (err) {
+      console.error("POST /api/admin/educators/:userId/reject error:", err);
+      return res.status(500).json({ error: "Failed to reject educator" });
+    }
+  },
+);
 
 module.exports = router;

--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -10,6 +10,7 @@ const express = require("express");
 const router = express.Router();
 const { body, param, validationResult } = require("express-validator");
 const { rateLimit, ipKeyGenerator } = require("express-rate-limit");
+const buildRateLimitStore = require("../lib/rateLimitStore");
 
 const { authenticate } = require("../middleware/auth");
 const db = require("../models");
@@ -20,7 +21,9 @@ const { rejectEducator } = require("../harjoot/usecases/rejectEducator");
 // Per Phase 9 plan: 100/hour per admin wallet. Even with only one admin
 // today, a runaway script that loops over a list of educator IDs should be
 // throttled rather than smash the DB + email provider. Keyed by the
-// authenticated wallet; ipKeyGenerator is the IPv6-safe fallback.
+// authenticated wallet; ipKeyGenerator is the IPv6-safe fallback. The
+// store is shared via Redis when REDIS_URL is set so multi-instance
+// deployments enforce a single effective limit.
 const adminEducatorLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 100,
@@ -28,6 +31,7 @@ const adminEducatorLimiter = rateLimit({
   legacyHeaders: false,
   message: { error: "Too many admin actions. Try again in an hour." },
   keyGenerator: (req) => (req.auth && req.auth.wallet) || ipKeyGenerator(req),
+  store: buildRateLimitStore("/api/admin/educators"),
 });
 
 // Guard — restrict a route to the configured admin wallet. Mirrors the

--- a/backend/routes/certificates.js
+++ b/backend/routes/certificates.js
@@ -1,4 +1,6 @@
 const express = require("express");
+const multer = require("multer");
+const { rateLimit, ipKeyGenerator } = require("express-rate-limit");
 const { PinataSDK } = require("pinata");
 const router = express.Router();
 
@@ -11,10 +13,66 @@ const { body, validationResult } = require("express-validator");
 const db = require("../models");
 const { Certificate, Student, Issuer, User, sequelize } = require("../models");
 const { authenticate } = require("../middleware/auth");
+const { requireHarjootAccess } = require("../middleware/harjootAccess");
 const emailService = require("../services/emailService");
 const paymentService = require("../services/paymentService");
+const ipfsCertificateUploader = require("../services/ipfsCertificateUploader");
 const { inviteTalent } = require("../harjoot/usecases/inviteTalent");
 const { precheckCertificate } = require("../harjoot/usecases/precheckCertificate");
+const { issueCertificate } = require("../harjoot/usecases/issueCertificate");
+const { createHarjootClient } = require("../harjoot/client");
+const { createPolygonProvider } = require("../harjoot/adapters/polygonProvider");
+const { createNftMintAdapter } = require("../harjoot/adapters/nftMintAdapter");
+
+// PDF certificates are larger than profile images. 10 MB matches a typical
+// printer-resolution single-page PDF with embedded fonts and one image.
+const ISSUE_MAX_FILE_SIZE = 10 * 1024 * 1024;
+const issueUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: ISSUE_MAX_FILE_SIZE },
+});
+
+// Per the Phase 9 plan: 10/hour per wallet. Wallets cannot bypass by
+// rotating IPs because we key on the authenticated identity, not req.ip.
+const issueLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many issuance attempts. Try again in an hour." },
+  // Key by the authenticated wallet so rotating IPs cannot bypass the
+  // limit. Pre-auth requests (none reach here today, but defense in depth)
+  // fall back to the IPv6-safe ip helper from express-rate-limit.
+  keyGenerator: (req) => (req.auth && req.auth.wallet) || ipKeyGenerator(req),
+});
+
+const TX_HASH_REGEX = /^0x[a-fA-F0-9]{64}$/;
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+// Reasons surfaced by issueCertificate -> HTTP status. Kept as a flat
+// lookup so the route handler stays a short switch. Default falls through
+// to 500 which is the safe choice for any unexpected reason.
+const ISSUE_REASON_HTTP = {
+  EDUCATOR_NOT_APPROVED: 403,
+  TALENT_NOT_FOUND: 404,
+  // Payment input the issuer can correct (wrong tx, wrong amount).
+  TX_NOT_FOUND: 422,
+  TX_REVERTED: 422,
+  NO_HACK_TRANSFER: 422,
+  WRONG_RECIPIENT: 422,
+  WRONG_SENDER: 422,
+  INSUFFICIENT_AMOUNT: 422,
+  // Conflict: this tx_hash already funded a previous certificate.
+  REPLAY: 409,
+  // Upstream / infra.
+  RPC_ERROR: 503,
+  IPFS_FAILED: 502,
+  HARJOOT_UPLOAD_FAILED: 502,
+  MINT_FAILED: 502,
+  // Persist after a successful mint = our bug. Should never happen in
+  // normal operation; ops alert + reconciliation expected.
+  PERSIST_FAILED: 500,
+};
 
 // Lowercased 0x-prefixed Ethereum address.
 function isHexWallet(value) {
@@ -106,18 +164,82 @@ router.post(
  * Flow: verify HACK payment -> hash PDF -> pin to IPFS -> Harjoot upload
  *       (hash_only) -> mint soulbound NFT -> persist -> queue treasury transfer.
  */
-router.post("/issue", authenticate, (req, res) => {
-  if (req.auth.role !== "issuer") {
-    return res.status(403).json({ error: "Only issuers can issue certificates" });
-  }
-  // TODO(impl): DS Section 4 issuance. Requires the harjootAccess middleware,
-  //  multer for the PDF upload, paymentService.verifyHackPayment(),
-  //  harjootService.uploadCertificate(), the on-chain mint adapter, and an
-  //  INSERT into `treasury_transfers_queue`.
-  return res
-    .status(501)
-    .json({ error: "Not implemented — see documents/harjoot-integration-handoff.md" });
-});
+router.post(
+  "/issue",
+  authenticate,
+  requireHarjootAccess,    // Section 3 — cache-aside membership refresh; non-blocking.
+  issueLimiter,
+  issueUpload.single("pdfFile"),
+  [
+    body("studentWallet").custom(isHexWallet)
+      .withMessage("studentWallet must be a 0x-prefixed 40-hex address"),
+    body("title").isString().trim().isLength({ min: 1, max: 255 })
+      .withMessage("title is required (<= 255 chars)"),
+    body("description").optional({ nullable: true }).isString().isLength({ max: 2000 }),
+    body("issue_date").matches(ISO_DATE_REGEX)
+      .withMessage("issue_date must be YYYY-MM-DD"),
+    body("paymentTxHash").matches(TX_HASH_REGEX)
+      .withMessage("paymentTxHash must be 0x-prefixed 32-byte hash"),
+  ],
+  async (req, res) => {
+    if (req.auth.role !== "issuer") {
+      return res.status(403).json({ error: "Only issuers can issue certificates" });
+    }
+    if (!req.file) {
+      return res.status(400).json({ error: "pdfFile is required (multipart/form-data)" });
+    }
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(422).json({ error: "validation_failed", details: errors.array() });
+    }
+
+    try {
+      const educator = await User.findByPk(req.auth.sub);
+      if (!educator || educator.role !== "issuer") {
+        return res.status(403).json({ error: "Only issuers can issue certificates" });
+      }
+
+      const result = await issueCertificate({
+        models: db,
+        paymentService,
+        harjootClient: createHarjootClient(),
+        mintAdapter: createNftMintAdapter(),
+        ipfsUpload: ipfsCertificateUploader.uploadCertificate,
+        provider: createPolygonProvider(),
+        educator,
+        studentWallet: req.body.studentWallet,
+        title: req.body.title,
+        description: req.body.description || null,
+        issueDate: req.body.issue_date,
+        paymentTxHash: req.body.paymentTxHash,
+        pdfBuffer: req.file.buffer,
+        pdfFileName: req.file.originalname || "certificate.pdf",
+      });
+
+      if (result.ok) {
+        return res.status(200).json({ ok: true, certificate: result.certificate });
+      }
+
+      const status = ISSUE_REASON_HTTP[result.reason] || 500;
+      const body = { error: result.reason || "ISSUE_FAILED" };
+      // Pass through useful context without leaking internals like stack
+      // traces. paymentId / verificationId / tokenId let the frontend show
+      // accurate UX or build a "contact support" CTA.
+      if (result.paymentId)       body.paymentId       = result.paymentId;
+      if (result.verificationId)  body.verificationId  = result.verificationId;
+      if (result.tokenId)         body.tokenId         = result.tokenId;
+      if (result.txHash)          body.txHash          = result.txHash;
+      if (result.existingPaymentId) body.existingPaymentId = result.existingPaymentId;
+      return res.status(status).json(body);
+    } catch (err) {
+      if (err && err.code === "LIMIT_FILE_SIZE") {
+        return res.status(413).json({ error: "pdfFile exceeds the 10 MB limit" });
+      }
+      console.error("[/issue] unexpected error:", err && err.message);
+      return res.status(500).json({ error: "ISSUE_FAILED" });
+    }
+  },
+);
 
 /**
  * POST /api/certificates/invite-talent

--- a/backend/routes/certificates.js
+++ b/backend/routes/certificates.js
@@ -1,6 +1,7 @@
 const express = require("express");
 const multer = require("multer");
 const { rateLimit, ipKeyGenerator } = require("express-rate-limit");
+const buildRateLimitStore = require("../lib/rateLimitStore");
 const { PinataSDK } = require("pinata");
 const router = express.Router();
 
@@ -34,6 +35,8 @@ const issueUpload = multer({
 
 // Per the Phase 9 plan: 10/hour per wallet. Wallets cannot bypass by
 // rotating IPs because we key on the authenticated identity, not req.ip.
+// `store` is shared via Redis when REDIS_URL is set so multi-instance
+// deployments enforce a single effective limit.
 const issueLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 10,
@@ -44,6 +47,7 @@ const issueLimiter = rateLimit({
   // limit. Pre-auth requests (none reach here today, but defense in depth)
   // fall back to the IPv6-safe ip helper from express-rate-limit.
   keyGenerator: (req) => (req.auth && req.auth.wallet) || ipKeyGenerator(req),
+  store: buildRateLimitStore("/api/certificates/issue"),
 });
 
 // Per the Phase 9 plan: 20/day per educator wallet. Sending invites is
@@ -56,6 +60,7 @@ const inviteTalentLimiter = rateLimit({
   legacyHeaders: false,
   message: { error: "Too many invitations. Try again tomorrow." },
   keyGenerator: (req) => (req.auth && req.auth.wallet) || ipKeyGenerator(req),
+  store: buildRateLimitStore("/api/certificates/invite-talent"),
 });
 
 const TX_HASH_REGEX = /^0x[a-fA-F0-9]{64}$/;

--- a/backend/routes/certificates.js
+++ b/backend/routes/certificates.js
@@ -46,6 +46,18 @@ const issueLimiter = rateLimit({
   keyGenerator: (req) => (req.auth && req.auth.wallet) || ipKeyGenerator(req),
 });
 
+// Per the Phase 9 plan: 20/day per educator wallet. Sending invites is
+// an email side effect; we want to throttle the case where an issuer
+// scripts a CSV import and accidentally spams a hundred talents.
+const inviteTalentLimiter = rateLimit({
+  windowMs: 24 * 60 * 60 * 1000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many invitations. Try again tomorrow." },
+  keyGenerator: (req) => (req.auth && req.auth.wallet) || ipKeyGenerator(req),
+});
+
 const TX_HASH_REGEX = /^0x[a-fA-F0-9]{64}$/;
 const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -254,6 +266,7 @@ router.post(
 router.post(
   "/invite-talent",
   authenticate,
+  inviteTalentLimiter,
   [
     body("studentWallet").custom(isHexWallet).withMessage("studentWallet must be a valid 0x-prefixed Ethereum address"),
     body("email").isEmail().withMessage("email must be a valid address").isLength({ max: 255 }),

--- a/backend/routes/certificates.js
+++ b/backend/routes/certificates.js
@@ -12,7 +12,9 @@ const db = require("../models");
 const { Certificate, Student, Issuer, User, sequelize } = require("../models");
 const { authenticate } = require("../middleware/auth");
 const emailService = require("../services/emailService");
+const paymentService = require("../services/paymentService");
 const { inviteTalent } = require("../harjoot/usecases/inviteTalent");
+const { precheckCertificate } = require("../harjoot/usecases/precheckCertificate");
 
 // Lowercased 0x-prefixed Ethereum address.
 function isHexWallet(value) {
@@ -38,18 +40,61 @@ function isHexWallet(value) {
  * Treasury / HACK token addresses, or an error code the form can act on.
  * Error codes: EDUCATOR_NOT_APPROVED | TALENT_NOT_FOUND.
  */
-router.post("/precheck", authenticate, (req, res) => {
-  if (req.auth.role !== "issuer") {
-    return res.status(403).json({ error: "Only issuers can issue certificates" });
-  }
-  // TODO(impl): DS Section 4 precheck.
-  //  - SELECT educator_approval_status; if not 'approved' -> EDUCATOR_NOT_APPROVED.
-  //  - SELECT user by studentWallet with role 'student'; if none -> TALENT_NOT_FOUND.
-  //  - paymentService.calculateMintPrice() -> { amountHack, ... }.
-  return res
-    .status(501)
-    .json({ error: "Not implemented — see documents/harjoot-integration-handoff.md" });
-});
+router.post(
+  "/precheck",
+  authenticate,
+  [body("studentWallet").custom(isHexWallet).withMessage("studentWallet must be a 0x-prefixed 40-hex address")],
+  async (req, res) => {
+    if (req.auth.role !== "issuer") {
+      return res.status(403).json({ error: "Only issuers can issue certificates" });
+    }
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(422).json({ error: "validation_failed", details: errors.array() });
+    }
+
+    try {
+      const educator = await User.findByPk(req.auth.sub);
+      if (!educator || educator.role !== "issuer") {
+        // Token says issuer but DB disagrees — treat as auth failure rather than 500.
+        return res.status(403).json({ error: "Only issuers can issue certificates" });
+      }
+
+      const result = await precheckCertificate({
+        models: db,
+        paymentService,
+        educator,
+        studentWallet: req.body.studentWallet,
+      });
+
+      if (!result.ok) {
+        if (result.reason === "EDUCATOR_NOT_APPROVED") {
+          return res.status(403).json({ error: "EDUCATOR_NOT_APPROVED" });
+        }
+        if (result.reason === "TALENT_NOT_FOUND") {
+          return res.status(404).json({ error: "TALENT_NOT_FOUND" });
+        }
+        return res.status(400).json({ error: result.reason || "PRECHECK_FAILED" });
+      }
+
+      // bigint cannot be serialized by JSON.stringify; expose the decimal
+      // string and let the frontend reconstruct a BigInt if it needs to.
+      return res.status(200).json({
+        ok: true,
+        price: {
+          amountHack: result.price.amountHackString,
+          userPriceUsdCents: result.price.userPriceUsdCents,
+          treasuryAddress: result.price.treasuryAddress,
+          hackTokenAddress: result.price.hackTokenAddress,
+        },
+        talent: result.talent,
+      });
+    } catch (err) {
+      console.error("[/precheck] error:", err && err.message);
+      return res.status(500).json({ error: "PRECHECK_FAILED" });
+    }
+  },
+);
 
 /**
  * POST /api/certificates/issue

--- a/backend/routes/certificates.js
+++ b/backend/routes/certificates.js
@@ -7,8 +7,17 @@ const pinata = new PinataSDK({
   pinataGateway: process.env.GATEWAY_URL,
 });
 
+const { body, validationResult } = require("express-validator");
+const db = require("../models");
 const { Certificate, Student, Issuer, User, sequelize } = require("../models");
 const { authenticate } = require("../middleware/auth");
+const emailService = require("../services/emailService");
+const { inviteTalent } = require("../harjoot/usecases/inviteTalent");
+
+// Lowercased 0x-prefixed Ethereum address.
+function isHexWallet(value) {
+  return typeof value === "string" && /^0x[a-fA-F0-9]{40}$/.test(value);
+}
 
 // ===========================================================================
 // Harjoot integration — SKELETON routes (DS Sections 4 and 5).
@@ -67,22 +76,74 @@ router.post("/issue", authenticate, (req, res) => {
 
 /**
  * POST /api/certificates/invite-talent
- * DS Section 5 — invite an unregistered talent by email. When precheck returns
- * TALENT_NOT_FOUND the educator can invite the talent to register.
- * Body: { studentWallet, email, message? }.
+ * DS Section 5 — invite an unregistered talent by email. Typically called
+ * after Section 4's precheck returns TALENT_NOT_FOUND. Dedupes per
+ * (educator, wallet) so re-clicks don't spam the invitee.
+ *
+ * Body: { studentWallet, email, message? }
+ * Returns: 200 { invitation } | 409 INVITE_ALREADY_PENDING
+ *          | 403 EDUCATOR_NOT_APPROVED | 422 validation
  */
-router.post("/invite-talent", authenticate, (req, res) => {
-  if (req.auth.role !== "issuer") {
-    return res.status(403).json({ error: "Only issuers can invite talents" });
-  }
-  // TODO(impl): DS Section 5.
-  //  - INSERT into `talent_invitations` { educator_user_id,
-  //    student_wallet_address, email, status:'pending' }.
-  //  - emailService: send the invitation email to the talent.
-  return res
-    .status(501)
-    .json({ error: "Not implemented — see documents/harjoot-integration-handoff.md" });
-});
+router.post(
+  "/invite-talent",
+  authenticate,
+  [
+    body("studentWallet").custom(isHexWallet).withMessage("studentWallet must be a valid 0x-prefixed Ethereum address"),
+    body("email").isEmail().withMessage("email must be a valid address").isLength({ max: 255 }),
+    body("message").optional({ nullable: true }).isString().isLength({ max: 2000 }),
+  ],
+  async (req, res) => {
+    if (req.auth.role !== "issuer") {
+      return res.status(403).json({ error: "Only issuers can invite talents" });
+    }
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(422).json({ errors: errors.array() });
+    }
+
+    try {
+      const educator = await User.findByPk(req.auth.sub);
+      if (!educator) {
+        return res.status(404).json({ error: "Educator not found" });
+      }
+      if (educator.educator_approval_status !== "approved") {
+        return res.status(403).json({ error: "EDUCATOR_NOT_APPROVED" });
+      }
+
+      const result = await inviteTalent({
+        models: db,
+        emailService,
+        educator,
+        studentWallet: req.body.studentWallet,
+        email: req.body.email,
+        message: req.body.message,
+      });
+
+      if (!result.ok) {
+        if (result.reason === "INVITE_ALREADY_PENDING") {
+          return res.status(409).json({
+            error: "INVITE_ALREADY_PENDING",
+            invitation: { id: result.invitation.id, status: result.invitation.status },
+          });
+        }
+        return res.status(400).json({ error: result.reason || "Failed to invite talent" });
+      }
+
+      return res.json({
+        message: "Talent invited",
+        invitation: {
+          id: result.invitation.id,
+          student_wallet_address: result.invitation.student_wallet_address,
+          email: result.invitation.email,
+          status: result.invitation.status,
+        },
+      });
+    } catch (err) {
+      console.error("POST /api/certificates/invite-talent error:", err);
+      return res.status(500).json({ error: "Failed to invite talent" });
+    }
+  },
+);
 
 // POST /api/certificates: Upload certificate metadata to Pinata
 router.post("/", authenticate, async (req, res) => {

--- a/backend/routes/issuers.js
+++ b/backend/routes/issuers.js
@@ -61,22 +61,36 @@ router.get("/me", authenticate, async (req, res) => {
 
 /**
  * GET /api/issuers/me/status
- * DS Section 2.5 — SKELETON. Educator approval status for the authenticated
- * issuer. Returns one of: pending_approval | rejected | approved (with the
- * reason when rejected). The educator dashboard uses this to gate certificate
- * issuance. Implementation pending — see documents/harjoot-integration-handoff.md.
+ * DS Section 2.5 — educator approval status for the authenticated issuer.
+ * Returns one of pending_approval | rejected | approved. When rejected the
+ * body also carries the reason; when approved it carries the approved_at
+ * timestamp. The educator dashboard uses this to gate the issuance UI.
  */
-router.get("/me/status", authenticate, (req, res) => {
+router.get("/me/status", authenticate, async (req, res) => {
   if (req.auth.role !== "issuer") {
     return res.status(403).json({ error: "Only educator accounts can access this endpoint" });
   }
-  // TODO(impl): DS Section 2.5.
-  //  - SELECT educator_approval_status (+ rejection_reason) FROM users
-  //    WHERE id = req.auth.sub.
-  //  - respond { status, reason? }.
-  return res
-    .status(501)
-    .json({ error: "Not implemented — see documents/harjoot-integration-handoff.md" });
+  try {
+    const user = await User.findByPk(req.auth.sub, {
+      attributes: ["educator_approval_status", "rejection_reason", "approved_at"],
+    });
+    if (!user) {
+      return res.status(404).json({ error: "User not found" });
+    }
+
+    const status = user.educator_approval_status || "pending_approval";
+    const body = { status };
+    if (status === "rejected" && user.rejection_reason) {
+      body.reason = user.rejection_reason;
+    }
+    if (status === "approved" && user.approved_at) {
+      body.approved_at = user.approved_at;
+    }
+    return res.json(body);
+  } catch (err) {
+    console.error("GET /api/issuers/me/status error:", err);
+    return res.status(500).json({ error: "Failed to fetch status" });
+  }
 });
 
 // GET /api/issuers  — public, paginated educator discovery

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -8,6 +8,8 @@ const { User, Student, Issuer, Recruiter, UserSession, sequelize } = require("..
 const { signToken, signRefreshToken, setAuthCookies, authenticate } = require("../middleware/auth");
 const { cacheSession } = require("../services/redis");
 const { authorizeIssuer } = require("../services/authorizeIssuer");
+const { createHarjootClient } = require("../harjoot/client");
+const { activateMembership } = require("../harjoot/usecases/activateMembership");
 
 const isValidEthAddress = (addr) => /^0x[a-fA-F0-9]{40}$/.test(addr);
 
@@ -67,6 +69,9 @@ router.post("/register", registerLimiter, async (req, res) => {
           email_verified: false,
           verification_token: verificationToken,
           verification_token_expires_at: verificationTokenExpiresAt,
+          // Issuers need explicit admin approval before they can issue certificates
+          // (DS Section 2.5). The status flips to "approved" via routes/admin.js.
+          educator_approval_status: role === "issuer" ? "pending_approval" : null,
         },
         { transaction: t }
       );
@@ -91,15 +96,17 @@ router.post("/register", registerLimiter, async (req, res) => {
       }
     });
 
-    // ----------------------------------------------------------------------
-    // DS Section 2 — Harjoot membership activation (SKELETON / pending).
-    // After the user + role profile are committed, register them in Harjoot:
-    //   await harjootService.activateAccess(role, newUser, roleSpecificData);
-    // Call it AFTER this transaction commits — never hold a DB transaction
-    // open on an external HTTP call. A failure here is non-fatal:
-    // middleware/harjootAccess.js lazily re-activates on the first protected
-    // request. See documents/harjoot-integration-handoff.md.
-    // ----------------------------------------------------------------------
+    // DS Section 2 — Harjoot membership activation. Runs AFTER the registration
+    // transaction commits so a Harjoot outage cannot abort the registration.
+    // The use case never throws; failures are logged and the membership
+    // middleware (Section 3) re-activates lazily on the first protected request.
+    await activateMembership({
+      client: createHarjootClient(),
+      models: { User },
+      role: newUser.role,
+      user: newUser,
+      profile: roleSpecificData,
+    });
 
     const payload = { sub: newUser.id, role: newUser.role, wallet: newUser.wallet_address };
     const token = signToken(payload);

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -4,12 +4,15 @@ const crypto = require("crypto");
 const jwt = require("jsonwebtoken");
 const rateLimit = require("express-rate-limit");
 
+const db = require("../models");
 const { User, Student, Issuer, Recruiter, UserSession, sequelize } = require("../models");
 const { signToken, signRefreshToken, setAuthCookies, authenticate } = require("../middleware/auth");
 const { cacheSession } = require("../services/redis");
 const { authorizeIssuer } = require("../services/authorizeIssuer");
+const emailService = require("../services/emailService");
 const { createHarjootClient } = require("../harjoot/client");
 const { activateMembership } = require("../harjoot/usecases/activateMembership");
+const { claimInvitation } = require("../harjoot/usecases/claimInvitation");
 
 const isValidEthAddress = (addr) => /^0x[a-fA-F0-9]{40}$/.test(addr);
 
@@ -107,6 +110,22 @@ router.post("/register", registerLimiter, async (req, res) => {
       user: newUser,
       profile: roleSpecificData,
     });
+
+    // DS Section 5 — claim any pending educator invitations targeting this
+    // wallet. Best effort: failures here (DB or email) must not block the
+    // registration response. Only students can have claimable invites.
+    if (newUser.role === "student") {
+      try {
+        await claimInvitation({
+          models: db,
+          emailService,
+          studentWallet: newUser.wallet_address,
+          studentUser: newUser,
+        });
+      } catch (err) {
+        console.error("[register] claimInvitation failed:", err && err.message);
+      }
+    }
 
     const payload = { sub: newUser.id, role: newUser.role, wallet: newUser.wallet_address };
     const token = signToken(payload);

--- a/backend/services/__tests__/paymentService.test.js
+++ b/backend/services/__tests__/paymentService.test.js
@@ -1,0 +1,95 @@
+// backend/services/__tests__/paymentService.test.js
+//
+// Unit tests for the pure pricing helper. Configuration is read at module
+// load time, so each test that needs a different env config must reset the
+// module cache and re-require both paymentService and harjoot/config.
+
+const ORIGINAL_ENV = { ...process.env };
+
+function loadFresh(envOverrides = {}) {
+  jest.resetModules();
+  // Restore env to baseline, then apply overrides.
+  process.env = { ...ORIGINAL_ENV, ...envOverrides };
+  // Order matters: paymentService requires harjoot/config which validates env.
+  return require("../paymentService");
+}
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  jest.resetModules();
+});
+
+describe("paymentService.calculateMintPrice", () => {
+  test("default launch pricing yields 6900 HACK ($0.69 / $0.0001)", () => {
+    const { calculateMintPrice } = loadFresh();
+    const result = calculateMintPrice();
+    expect(result.amountHack).toBe(6900n);
+    expect(result.userPriceUsdCents).toBe(69);
+    expect(result.harjootCostUsdCents).toBe(20);
+    expect(result.grossMarginUsdCents).toBe(49);
+  });
+
+  test("returns the configured treasury + HACK token addresses, lowercased", () => {
+    const { calculateMintPrice } = loadFresh({
+      TREASURY_ADDRESS: "0xABCDEF1234567890ABCDEF1234567890ABCDEF12",
+      HACK_TOKEN_ADDRESS: "0x1234567890ABCDEF1234567890ABCDEF12345678",
+    });
+    const result = calculateMintPrice();
+    expect(result.treasuryAddress).toBe("0xabcdef1234567890abcdef1234567890abcdef12");
+    expect(result.hackTokenAddress).toBe("0x1234567890abcdef1234567890abcdef12345678");
+  });
+
+  test("respects a custom USER_PRICE_USD_CENTS", () => {
+    const { calculateMintPrice } = loadFresh({ USER_PRICE_USD_CENTS: "100" });
+    // 100 cents * 10_000 micros/cent / 100 micros/HACK = 10000 HACK
+    expect(calculateMintPrice().amountHack).toBe(10000n);
+  });
+
+  test("respects a custom HACK_PRICE_USD_MICROS", () => {
+    // 1 HACK = $0.001 (1000 micros). 69 cents / $0.001 = 690 HACK.
+    const { calculateMintPrice } = loadFresh({ HACK_PRICE_USD_MICROS: "1000" });
+    expect(calculateMintPrice().amountHack).toBe(690n);
+  });
+
+  test("grossMarginUsdCents reflects USER_PRICE - HARJOOT_PRICE", () => {
+    const { calculateMintPrice } = loadFresh({
+      USER_PRICE_USD_CENTS: "200",
+      HARJOOT_PRICE_USD_CENTS: "50",
+    });
+    expect(calculateMintPrice().grossMarginUsdCents).toBe(150);
+  });
+
+  test("throws when pricing does not divide evenly (precision guard)", () => {
+    // 69 cents * 10_000 = 690_000 micros. 690_000 % 7 != 0.
+    const { calculateMintPrice } = loadFresh({ HACK_PRICE_USD_MICROS: "7" });
+    expect(() => calculateMintPrice()).toThrow(/does not divide evenly/i);
+  });
+
+  test("throws when HACK_PRICE_USD_MICROS is configured as zero", () => {
+    const { calculateMintPrice } = loadFresh({ HACK_PRICE_USD_MICROS: "0" });
+    expect(() => calculateMintPrice()).toThrow(/cannot be zero/i);
+  });
+});
+
+describe("harjoot/config address validation", () => {
+  test("rejects a malformed TREASURY_ADDRESS at module load", () => {
+    expect(() => loadFresh({ TREASURY_ADDRESS: "not-an-address" })).toThrow(
+      /TREASURY_ADDRESS must be a 0x-prefixed 40-hex-char address/i,
+    );
+  });
+
+  test("rejects a malformed HACK_TOKEN_ADDRESS at module load", () => {
+    expect(() => loadFresh({ HACK_TOKEN_ADDRESS: "0xdeadbeef" })).toThrow(
+      /HACK_TOKEN_ADDRESS must be a 0x-prefixed 40-hex-char address/i,
+    );
+  });
+});
+
+describe("paymentService.verifyHackPayment", () => {
+  // Phase 7c will implement this. Until then assert the stub explicitly so
+  // we don't ship a silent no-op by accident.
+  test("is still a stub (Phase 7c)", async () => {
+    const { verifyHackPayment } = loadFresh();
+    await expect(verifyHackPayment("0x00", "0x00", 0n)).rejects.toThrow(/not implemented/i);
+  });
+});

--- a/backend/services/__tests__/paymentService.test.js
+++ b/backend/services/__tests__/paymentService.test.js
@@ -85,11 +85,6 @@ describe("harjoot/config address validation", () => {
   });
 });
 
-describe("paymentService.verifyHackPayment", () => {
-  // Phase 7c will implement this. Until then assert the stub explicitly so
-  // we don't ship a silent no-op by accident.
-  test("is still a stub (Phase 7c)", async () => {
-    const { verifyHackPayment } = loadFresh();
-    await expect(verifyHackPayment("0x00", "0x00", 0n)).rejects.toThrow(/not implemented/i);
-  });
-});
+// Note: paymentService.verifyHackPayment has its own dedicated suite
+// at services/__tests__/verifyHackPayment.test.js — receipt decoding,
+// replay protection, and persistence are exercised there with SQLite.

--- a/backend/services/__tests__/verifyHackPayment.test.js
+++ b/backend/services/__tests__/verifyHackPayment.test.js
@@ -484,6 +484,112 @@ describe("paymentService.verifyHackPayment", () => {
   });
 
   // -------------------------------------------------------------------------
+  // SECURITY: tx_hash case-sensitivity replay protection
+  // -------------------------------------------------------------------------
+
+  describe("tx_hash case-sensitivity replay protection", () => {
+    // Same hash bytes, different ASCII casing. Without normalization Postgres
+    // treats these as two distinct rows -> double-spend vulnerability.
+    const MIXED_CASE_TX = "0x" + "AbCdEf1234567890".repeat(4);
+    const LOWER_CASE_TX = MIXED_CASE_TX.toLowerCase();
+
+    function happyReceipt() {
+      return makeReceipt({
+        logs: [
+          makeTransferLog({
+            tokenAddress: HACK_TOKEN,
+            from: EDUCATOR,
+            to: TREASURY,
+            value: EXPECTED_BASE,
+          }),
+        ],
+      });
+    }
+
+    test("persists tx_hash in lowercase regardless of input casing", async () => {
+      const result = await verifyHackPayment({
+        models,
+        provider: makeProvider({ receipt: happyReceipt() }),
+        txHash: MIXED_CASE_TX,
+        expectedFrom: EDUCATOR,
+        expectedAmountHack: EXPECTED_HACK,
+        purpose: "certificate_issuance",
+        pricing: DEFAULT_PRICING,
+        config: STUB_CONFIG,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.payment.txHash).toBe(LOWER_CASE_TX);
+
+      const stored = await Payment.findOne({ where: { tx_hash: LOWER_CASE_TX } });
+      expect(stored).not.toBeNull();
+      // Nothing slipped through with the mixed casing.
+      const mixedStored = await Payment.findOne({ where: { tx_hash: MIXED_CASE_TX } });
+      expect(mixedStored).toBeNull();
+    });
+
+    test("REPLAY when a payment with the lowercase hash already exists", async () => {
+      // Insert the lowercase hash first, then try to verify with mixed case.
+      await Payment.create({
+        tx_hash: LOWER_CASE_TX,
+        from_wallet: EDUCATOR,
+        amount_hack: EXPECTED_HACK.toString(),
+        harjoot_price_usd: "0.2000",
+        user_price_usd: "0.6900",
+        status: "confirmed",
+        purpose: "certificate_issuance",
+      });
+
+      const result = await verifyHackPayment({
+        models,
+        provider: makeProvider({ receipt: null }),
+        txHash: MIXED_CASE_TX,
+        expectedFrom: EDUCATOR,
+        expectedAmountHack: EXPECTED_HACK,
+        purpose: "certificate_issuance",
+        pricing: DEFAULT_PRICING,
+        config: STUB_CONFIG,
+      });
+
+      expect(result.reason).toBe("REPLAY");
+      expect(await Payment.count()).toBe(1);
+    });
+
+    test("two verifications with different casings of the same hash hit REPLAY on the second", async () => {
+      // First call wins.
+      const first = await verifyHackPayment({
+        models,
+        provider: makeProvider({ receipt: happyReceipt() }),
+        txHash: MIXED_CASE_TX,
+        expectedFrom: EDUCATOR,
+        expectedAmountHack: EXPECTED_HACK,
+        purpose: "certificate_issuance",
+        pricing: DEFAULT_PRICING,
+        config: STUB_CONFIG,
+      });
+      expect(first.ok).toBe(true);
+
+      // Second call with the OPPOSITE casing must NOT mint a duplicate.
+      const second = await verifyHackPayment({
+        models,
+        provider: makeProvider({ receipt: happyReceipt() }),
+        txHash: LOWER_CASE_TX, // would have been a different string in DB without the fix
+        expectedFrom: EDUCATOR,
+        expectedAmountHack: EXPECTED_HACK,
+        purpose: "certificate_issuance",
+        pricing: DEFAULT_PRICING,
+        config: STUB_CONFIG,
+      });
+      expect(second.ok).toBe(false);
+      expect(second.reason).toBe("REPLAY");
+      expect(second.existingPaymentId).toBe(first.payment.id);
+
+      // Exactly one row, never two.
+      expect(await Payment.count()).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Programmer errors
   // -------------------------------------------------------------------------
 

--- a/backend/services/__tests__/verifyHackPayment.test.js
+++ b/backend/services/__tests__/verifyHackPayment.test.js
@@ -1,0 +1,586 @@
+// backend/services/__tests__/verifyHackPayment.test.js
+//
+// Exercises the receipt-decoding logic + replay protection + persistence
+// path of paymentService.verifyHackPayment. SQLite in-memory provides
+// the real Payment model + the tx_hash unique constraint; the chain is
+// stubbed through a minimal provider double that returns canned receipts.
+
+const SequelizePkg = require("sequelize");
+const { Interface } = require("ethers");
+
+const { verifyHackPayment, __TRANSFER_TOPIC0 } = require("../paymentService");
+
+// Addresses are 0x + 40 hex chars (20 bytes). ethers parses these so they
+// must be syntactically valid even when they don't point at a real contract.
+const HACK_TOKEN  = "0x0000000000000000000000000000000000000ace";
+const TREASURY    = "0x0000000000000000000000000000000000000bee";
+const EDUCATOR    = "0x1111111111111111111111111111111111111111";
+const OTHER_USER  = "0x2222222222222222222222222222222222222222";
+const OTHER_TOKEN = "0x9999999999999999999999999999999999999999";
+
+// 6900 whole HACK at 18 decimals = 6900 * 10^18.
+const DECIMALS = 18;
+const SCALE = 10n ** BigInt(DECIMALS);
+const EXPECTED_HACK = 6900n;
+const EXPECTED_BASE = EXPECTED_HACK * SCALE;
+
+const DEFAULT_TX = "0x" + "ab".repeat(32);
+const DEFAULT_PRICING = { harjootCostUsdCents: 20, userPriceUsdCents: 69 };
+
+// Override the harjoot config for these tests so we don't depend on env.
+const STUB_CONFIG = {
+  chain: {
+    treasuryAddress: TREASURY,
+    hackTokenAddress: HACK_TOKEN,
+    hackTokenDecimals: DECIMALS,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const transferIface = new Interface([
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+]);
+
+function makeTransferLog({ tokenAddress, from, to, value }) {
+  const encoded = transferIface.encodeEventLog("Transfer", [from, to, value]);
+  return {
+    address: tokenAddress,
+    topics: encoded.topics,
+    data: encoded.data,
+  };
+}
+
+function makeReceipt({ status = 1, logs = [] } = {}) {
+  return { status, logs };
+}
+
+function makeProvider({ receipt = null, error = null } = {}) {
+  return {
+    async getTransactionReceipt(_txHash) {
+      if (error) throw error;
+      return receipt;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("paymentService.verifyHackPayment", () => {
+  let sequelize;
+  let Payment;
+  let models;
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    const { DataTypes } = SequelizePkg;
+    Payment = require("../../models/payments")(sequelize, DataTypes);
+    await sequelize.sync({ force: true });
+    models = { Payment };
+
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    if (sequelize) await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  test("confirms an exact-amount payment, persists payments row, returns ok", async () => {
+    const receipt = makeReceipt({
+      logs: [
+        makeTransferLog({
+          tokenAddress: HACK_TOKEN,
+          from: EDUCATOR,
+          to: TREASURY,
+          value: EXPECTED_BASE,
+        }),
+      ],
+    });
+    const provider = makeProvider({ receipt });
+
+    const result = await verifyHackPayment({
+      models,
+      provider,
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.payment.txHash).toBe(DEFAULT_TX);
+    expect(result.payment.fromWallet).toBe(EDUCATOR);
+    expect(result.payment.amountHack).toBe(EXPECTED_HACK);
+
+    const row = await Payment.findOne({ where: { tx_hash: DEFAULT_TX } });
+    expect(row).not.toBeNull();
+    expect(row.from_wallet).toBe(EDUCATOR);
+    expect(BigInt(row.amount_hack)).toBe(EXPECTED_HACK);
+    expect(row.status).toBe("confirmed");
+    expect(row.purpose).toBe("certificate_issuance");
+    // DECIMAL columns come back as number in SQLite, "0.2000" in Postgres.
+    // Compare as numbers so the assertion is portable across drivers.
+    expect(Number(row.harjoot_price_usd)).toBeCloseTo(0.2, 4);
+    expect(Number(row.user_price_usd)).toBeCloseTo(0.69, 4);
+  });
+
+  test("accepts an overpayment and stores the actual amount paid", async () => {
+    const receipt = makeReceipt({
+      logs: [
+        makeTransferLog({
+          tokenAddress: HACK_TOKEN,
+          from: EDUCATOR,
+          to: TREASURY,
+          value: EXPECTED_BASE * 2n,
+        }),
+      ],
+    });
+
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.payment.amountHack).toBe(EXPECTED_HACK * 2n);
+  });
+
+  test("sums multiple HACK->treasury transfers from the same educator in one tx", async () => {
+    // Router-style path: two internal hops both ending at treasury.
+    const half = EXPECTED_BASE / 2n;
+    const receipt = makeReceipt({
+      logs: [
+        makeTransferLog({ tokenAddress: HACK_TOKEN, from: EDUCATOR, to: TREASURY, value: half }),
+        makeTransferLog({ tokenAddress: HACK_TOKEN, from: EDUCATOR, to: TREASURY, value: half }),
+      ],
+    });
+
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.payment.amountHack).toBe(EXPECTED_HACK);
+  });
+
+  test("accepts mixed-case expectedFrom (lowercases internally)", async () => {
+    const receipt = makeReceipt({
+      logs: [
+        makeTransferLog({
+          tokenAddress: HACK_TOKEN,
+          from: EDUCATOR,
+          to: TREASURY,
+          value: EXPECTED_BASE,
+        }),
+      ],
+    });
+
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR.toUpperCase().replace(/X/g, "x"),
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Receipt-level failures
+  // -------------------------------------------------------------------------
+
+  test("returns TX_NOT_FOUND when provider returns null", async () => {
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt: null }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+    expect(result).toEqual({ ok: false, reason: "TX_NOT_FOUND" });
+    expect(await Payment.count()).toBe(0);
+  });
+
+  test("returns TX_REVERTED when receipt.status === 0", async () => {
+    const receipt = makeReceipt({
+      status: 0,
+      logs: [
+        makeTransferLog({ tokenAddress: HACK_TOKEN, from: EDUCATOR, to: TREASURY, value: EXPECTED_BASE }),
+      ],
+    });
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+    expect(result.reason).toBe("TX_REVERTED");
+    expect(await Payment.count()).toBe(0);
+  });
+
+  test("RPC_ERROR is soft-failed and does NOT persist a row", async () => {
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ error: new Error("RPC blew up") }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("RPC_ERROR");
+    expect(result.soft_failed).toBe(true);
+    expect(await Payment.count()).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Transfer-event failures
+  // -------------------------------------------------------------------------
+
+  test("NO_HACK_TRANSFER when no log is from the HACK token contract", async () => {
+    const receipt = makeReceipt({
+      logs: [
+        makeTransferLog({ tokenAddress: OTHER_TOKEN, from: EDUCATOR, to: TREASURY, value: EXPECTED_BASE }),
+      ],
+    });
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+    expect(result.reason).toBe("NO_HACK_TRANSFER");
+  });
+
+  test("NO_HACK_TRANSFER when receipt has empty logs array", async () => {
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt: makeReceipt({ logs: [] }) }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+    expect(result.reason).toBe("NO_HACK_TRANSFER");
+  });
+
+  test("WRONG_RECIPIENT when HACK transfer goes to someone other than treasury", async () => {
+    const receipt = makeReceipt({
+      logs: [
+        makeTransferLog({ tokenAddress: HACK_TOKEN, from: EDUCATOR, to: OTHER_USER, value: EXPECTED_BASE }),
+      ],
+    });
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+    expect(result.reason).toBe("WRONG_RECIPIENT");
+  });
+
+  test("WRONG_SENDER when HACK arrives at treasury but from someone else", async () => {
+    const receipt = makeReceipt({
+      logs: [
+        makeTransferLog({ tokenAddress: HACK_TOKEN, from: OTHER_USER, to: TREASURY, value: EXPECTED_BASE }),
+      ],
+    });
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+    expect(result.reason).toBe("WRONG_SENDER");
+  });
+
+  test("INSUFFICIENT_AMOUNT when educator paid less than expected", async () => {
+    const receipt = makeReceipt({
+      logs: [
+        makeTransferLog({
+          tokenAddress: HACK_TOKEN,
+          from: EDUCATOR,
+          to: TREASURY,
+          value: EXPECTED_BASE - 1n,
+        }),
+      ],
+    });
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+    expect(result.reason).toBe("INSUFFICIENT_AMOUNT");
+  });
+
+  test("ignores non-Transfer events emitted by the HACK contract", async () => {
+    // A log from the HACK contract whose topic[0] is NOT the Transfer hash —
+    // e.g. an Approval or a custom Pause event — must be silently skipped,
+    // not crash the verification.
+    const receipt = makeReceipt({
+      logs: [
+        {
+          address: HACK_TOKEN,
+          topics: ["0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"],
+          data: "0x",
+        },
+        makeTransferLog({ tokenAddress: HACK_TOKEN, from: EDUCATOR, to: TREASURY, value: EXPECTED_BASE }),
+      ],
+    });
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Replay protection
+  // -------------------------------------------------------------------------
+
+  test("REPLAY (pre-check hit) when tx_hash already exists in payments", async () => {
+    const existing = await Payment.create({
+      tx_hash: DEFAULT_TX,
+      from_wallet: EDUCATOR,
+      amount_hack: EXPECTED_HACK.toString(),
+      harjoot_price_usd: "0.2000",
+      user_price_usd: "0.6900",
+      status: "confirmed",
+      purpose: "certificate_issuance",
+    });
+
+    const result = await verifyHackPayment({
+      models,
+      provider: makeProvider({ receipt: null }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("REPLAY");
+    expect(result.existingPaymentId).toBe(existing.id);
+  });
+
+  test("REPLAY (race window) caught by unique constraint at INSERT time", async () => {
+    // Simulate a race: the pre-check passes, but somebody inserts BEFORE
+    // our INSERT runs. We patch findOne to return null on the first call
+    // and let create() hit the real unique constraint.
+    const receipt = makeReceipt({
+      logs: [
+        makeTransferLog({ tokenAddress: HACK_TOKEN, from: EDUCATOR, to: TREASURY, value: EXPECTED_BASE }),
+      ],
+    });
+
+    // Race-winner inserts FIRST.
+    const winner = await Payment.create({
+      tx_hash: DEFAULT_TX,
+      from_wallet: EDUCATOR,
+      amount_hack: EXPECTED_HACK.toString(),
+      harjoot_price_usd: "0.2000",
+      user_price_usd: "0.6900",
+      status: "confirmed",
+      purpose: "certificate_issuance",
+    });
+
+    // Now pretend our pre-check missed it (force findOne to return null
+    // exactly once, the rest of the run uses the real method).
+    const realFindOne = Payment.findOne.bind(Payment);
+    const spy = jest.spyOn(Payment, "findOne").mockImplementationOnce(async () => null);
+
+    const result = await verifyHackPayment({
+      models: { Payment },
+      provider: makeProvider({ receipt }),
+      txHash: DEFAULT_TX,
+      expectedFrom: EDUCATOR,
+      expectedAmountHack: EXPECTED_HACK,
+      purpose: "certificate_issuance",
+      pricing: DEFAULT_PRICING,
+      config: STUB_CONFIG,
+    });
+
+    spy.mockRestore();
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("REPLAY");
+    expect(result.existingPaymentId).toBe(winner.id);
+    expect(await Payment.count()).toBe(1); // race-winner still alone
+    // sanity: real findOne still works after restore
+    expect(await realFindOne({ where: { tx_hash: DEFAULT_TX } })).not.toBeNull();
+  });
+
+  // -------------------------------------------------------------------------
+  // Programmer errors
+  // -------------------------------------------------------------------------
+
+  test("throws TypeError on missing models", async () => {
+    await expect(
+      verifyHackPayment({
+        provider: makeProvider({ receipt: null }),
+        txHash: DEFAULT_TX,
+        expectedFrom: EDUCATOR,
+        expectedAmountHack: EXPECTED_HACK,
+        purpose: "certificate_issuance",
+        pricing: DEFAULT_PRICING,
+        config: STUB_CONFIG,
+      }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError on missing provider", async () => {
+    await expect(
+      verifyHackPayment({
+        models,
+        txHash: DEFAULT_TX,
+        expectedFrom: EDUCATOR,
+        expectedAmountHack: EXPECTED_HACK,
+        purpose: "certificate_issuance",
+        pricing: DEFAULT_PRICING,
+        config: STUB_CONFIG,
+      }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError on malformed txHash", async () => {
+    await expect(
+      verifyHackPayment({
+        models,
+        provider: makeProvider({ receipt: null }),
+        txHash: "not-a-hash",
+        expectedFrom: EDUCATOR,
+        expectedAmountHack: EXPECTED_HACK,
+        purpose: "certificate_issuance",
+        pricing: DEFAULT_PRICING,
+        config: STUB_CONFIG,
+      }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError on non-bigint expectedAmountHack", async () => {
+    await expect(
+      verifyHackPayment({
+        models,
+        provider: makeProvider({ receipt: null }),
+        txHash: DEFAULT_TX,
+        expectedFrom: EDUCATOR,
+        expectedAmountHack: 6900, // number, not bigint
+        purpose: "certificate_issuance",
+        pricing: DEFAULT_PRICING,
+        config: STUB_CONFIG,
+      }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError on zero or negative expectedAmountHack", async () => {
+    await expect(
+      verifyHackPayment({
+        models,
+        provider: makeProvider({ receipt: null }),
+        txHash: DEFAULT_TX,
+        expectedFrom: EDUCATOR,
+        expectedAmountHack: 0n,
+        purpose: "certificate_issuance",
+        pricing: DEFAULT_PRICING,
+        config: STUB_CONFIG,
+      }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError on missing pricing", async () => {
+    await expect(
+      verifyHackPayment({
+        models,
+        provider: makeProvider({ receipt: null }),
+        txHash: DEFAULT_TX,
+        expectedFrom: EDUCATOR,
+        expectedAmountHack: EXPECTED_HACK,
+        purpose: "certificate_issuance",
+        config: STUB_CONFIG,
+      }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  // -------------------------------------------------------------------------
+  // Sanity: TRANSFER_TOPIC0 matches the canonical hash
+  // -------------------------------------------------------------------------
+
+  test("TRANSFER_TOPIC0 equals keccak256(Transfer(address,address,uint256))", () => {
+    expect(__TRANSFER_TOPIC0).toBe(
+      "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+    );
+  });
+});

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -325,8 +325,90 @@ async function notifyEducatorRejected({ to, name, reason }) {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Talent invitation notifications (DS Section 5)
+// ---------------------------------------------------------------------------
+
+function shortenWallet(wallet) {
+  if (!wallet || typeof wallet !== "string") return wallet;
+  return wallet.length > 10 ? `${wallet.slice(0, 6)}…${wallet.slice(-4)}` : wallet;
+}
+
+async function sendInvite({ to, walletAddress, educatorName, message }) {
+  console.log(`[emailService] Enviando invitación de talento a: ${to}`);
+  const inviter = educatorName || "Un educador";
+  const registerUrl = `${FRONTEND_URL}/register?wallet=${encodeURIComponent(walletAddress || "")}`;
+  const safeMessage = typeof message === "string" && message.trim() ? message.trim() : null;
+  const shortWallet = shortenWallet(walletAddress);
+
+  const textParts = [
+    `Hola.`,
+    "",
+    `${inviter} te invitó a HackChain para emitirte un certificado verificado.`,
+    `Tu billetera (${shortWallet}) ya está identificada en la invitación.`,
+  ];
+  if (safeMessage) {
+    textParts.push("", `Mensaje del educador:`, `"${safeMessage}"`);
+  }
+  textParts.push(
+    "",
+    `Registrate y conectá esa misma billetera acá: ${registerUrl}`,
+    "",
+    `— Equipo HackChain`,
+  );
+
+  const htmlBody = `
+    <p style="margin:0 0 12px;">Hola.</p>
+    <p style="margin:0 0 12px;"><strong>${inviter}</strong> te invitó a HackChain para emitirte un certificado verificado.</p>
+    <p style="margin:0 0 12px;">Tu billetera <code style="background:#f1f1f5;padding:2px 6px;border-radius:4px;">${shortWallet || "—"}</code> ya está identificada en la invitación.</p>
+    ${safeMessage ? `<blockquote style="margin:16px 0;padding:12px 16px;border-left:4px solid #680099;background:#f9f4ff;color:#333;">${safeMessage}</blockquote>` : ""}
+    <p style="margin:0 0 12px;">Registrate y conectá esa misma billetera para reclamar tu certificado.</p>
+  `;
+
+  await resend.emails.send({
+    from: FROM,
+    to,
+    subject: `${inviter} te invitó a HackChain`,
+    text: textParts.join("\n"),
+    html: renderEducatorEmail({
+      title: "Invitación a HackChain",
+      headline: "Te invitaron a HackChain",
+      accentColor: "#680099",
+      body: htmlBody,
+      ctaUrl: registerUrl,
+      ctaLabel: "Registrate ahora",
+    }),
+  });
+}
+
+async function notifyEducatorClaimed({ to, educatorName, studentWallet, studentName }) {
+  console.log(`[emailService] Notificando claim a educador: ${to}`);
+  const greeting = educatorName ? `Hola, ${educatorName}.` : "Hola.";
+  const who = studentName ? `${studentName} (${shortenWallet(studentWallet)})` : shortenWallet(studentWallet);
+  const dashboardUrl = `${FRONTEND_URL}/educator-dashboard`;
+
+  await resend.emails.send({
+    from: FROM,
+    to,
+    subject: "El talento que invitaste se registró en HackChain",
+    text: `${greeting}\n\nEl talento que invitaste a HackChain ya se registró (${who}).\nYa podés reintentar la emisión del certificado desde tu dashboard.\n\nDashboard: ${dashboardUrl}\n\n— Equipo HackChain`,
+    html: renderEducatorEmail({
+      title: "Tu invitación fue reclamada",
+      headline: "Tu invitación fue reclamada",
+      accentColor: "#680099",
+      body: `<p style="margin:0 0 12px;">${greeting}</p>
+             <p style="margin:0 0 12px;">El talento que invitaste a HackChain (<strong>${who}</strong>) ya se registró.</p>
+             <p style="margin:0 0 12px;">Ya podés reintentar la emisión del certificado desde tu dashboard.</p>`,
+      ctaUrl: dashboardUrl,
+      ctaLabel: "Ir al dashboard",
+    }),
+  });
+}
+
 module.exports = {
   sendVerificationEmail,
   notifyEducatorApproved,
   notifyEducatorRejected,
+  sendInvite,
+  notifyEducatorClaimed,
 };

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -243,4 +243,90 @@ async function sendVerificationEmail({ to, name, token }) {
   });
 }
 
-module.exports = { sendVerificationEmail };
+// ---------------------------------------------------------------------------
+// Educator approval notifications (DS Section 2.5)
+// ---------------------------------------------------------------------------
+
+// Lightweight HTML template shared by both approve/reject emails. Keeps the
+// branded look without copying the 200-line verification template above.
+function renderEducatorEmail({ title, headline, body, ctaUrl, ctaLabel, accentColor }) {
+  return `<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${title}</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f9f9f9;font-family:'Cabin',Arial,sans-serif;color:#222;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#f9f9f9;padding:40px 16px;">
+    <tr><td align="center">
+      <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="background-color:#ffffff;border-radius:8px;overflow:hidden;max-width:600px;width:100%;">
+        <tr><td style="background-color:${accentColor};padding:24px;text-align:center;color:#ffffff;">
+          <h1 style="margin:0;font-size:22px;line-height:1.3;">${headline}</h1>
+        </td></tr>
+        <tr><td style="padding:32px 40px;font-size:16px;line-height:1.6;">
+          ${body}
+          ${ctaUrl ? `<p style="text-align:center;margin:32px 0 8px;">
+            <a href="${ctaUrl}" style="display:inline-block;background-color:${accentColor};color:#ffffff;text-decoration:none;padding:12px 28px;border-radius:6px;font-weight:700;">${ctaLabel}</a>
+          </p>` : ""}
+        </td></tr>
+        <tr><td style="background-color:#f1f1f5;padding:16px;text-align:center;font-size:12px;color:#888;">
+          &copy; HackChain
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`;
+}
+
+async function notifyEducatorApproved({ to, name }) {
+  console.log(`[emailService] Enviando aprobacion de educador a: ${to}`);
+  const greeting = name ? `Hola, ${name}.` : "Hola.";
+
+  await resend.emails.send({
+    from: FROM,
+    to,
+    subject: "¡Tu cuenta de educador en HackChain fue aprobada!",
+    text: `${greeting}\n\nTu cuenta de educador en HackChain fue aprobada. Ya podés emitir certificados desde tu dashboard.\n\nDashboard: ${FRONTEND_URL}/educator-dashboard\n\n— Equipo HackChain`,
+    html: renderEducatorEmail({
+      title: "Cuenta de educador aprobada",
+      headline: "¡Cuenta aprobada!",
+      accentColor: "#680099",
+      body: `<p style="margin:0 0 12px;">${greeting}</p>
+             <p style="margin:0 0 12px;">Tu cuenta de educador en HackChain fue <strong>aprobada</strong>. Ya podés emitir certificados desde tu dashboard.</p>`,
+      ctaUrl: `${FRONTEND_URL}/educator-dashboard`,
+      ctaLabel: "Ir al dashboard",
+    }),
+  });
+}
+
+async function notifyEducatorRejected({ to, name, reason }) {
+  console.log(`[emailService] Enviando rechazo de educador a: ${to}`);
+  const greeting = name ? `Hola, ${name}.` : "Hola.";
+  const safeReason = String(reason || "").trim() || "No se especificó motivo.";
+
+  await resend.emails.send({
+    from: FROM,
+    to,
+    subject: "Tu solicitud de educador en HackChain fue rechazada",
+    text: `${greeting}\n\nTu solicitud para ser educador en HackChain fue rechazada.\n\nMotivo: ${safeReason}\n\nSi creés que esto es un error, escribinos a contacto@hackchain.app.\n\n— Equipo HackChain`,
+    html: renderEducatorEmail({
+      title: "Solicitud de educador rechazada",
+      headline: "Solicitud rechazada",
+      accentColor: "#a13c3c",
+      body: `<p style="margin:0 0 12px;">${greeting}</p>
+             <p style="margin:0 0 12px;">Tu solicitud para ser educador en HackChain fue <strong>rechazada</strong>.</p>
+             <p style="margin:0 0 12px;"><strong>Motivo:</strong> ${safeReason}</p>
+             <p style="margin:0 0 12px;">Si creés que esto es un error, escribinos a <a href="mailto:contacto@hackchain.app" style="color:#680099;">contacto@hackchain.app</a>.</p>`,
+      ctaUrl: null,
+      ctaLabel: null,
+    }),
+  });
+}
+
+module.exports = {
+  sendVerificationEmail,
+  notifyEducatorApproved,
+  notifyEducatorRejected,
+};

--- a/backend/services/ipfsCertificateUploader.js
+++ b/backend/services/ipfsCertificateUploader.js
@@ -1,0 +1,129 @@
+// backend/services/ipfsCertificateUploader.js
+//
+// Pinata-backed implementation of the ipfsUpload port consumed by
+// harjoot/usecases/issueCertificate.js.
+//
+// Two pins per certificate:
+//   1. the raw PDF blob          -> pdfCid
+//   2. an ERC-721 metadata JSON  -> metadataCid (returned as tokenUri)
+//
+// Metadata follows the de-facto ERC-721 standard so marketplaces (OpenSea,
+// etc.) render the certificate. We do NOT include verificationId or external
+// URLs that depend on the Harjoot/Mint stages — those run AFTER this step
+// in the orchestrator, so the metadata must be derivable from inputs alone.
+//
+// The export shape matches the function signature the use case expects:
+//   uploadCertificate({ pdfBuffer, pdfFileName, title, description,
+//                       studentWallet, certificateHash, issueDate })
+//     -> Promise<{ tokenUri, pdfCid, metadataCid }>
+
+const { PinataSDK } = require("pinata");
+
+const LOG_PREFIX = "[ipfsCertificateUploader]";
+
+// Lazy singleton so importing this module never crashes when
+// PINATA_JWT is not set (tests). Real callers (route handler) trigger
+// the validation when the first upload happens.
+let cachedClient = null;
+
+function getPinata() {
+  if (cachedClient) return cachedClient;
+  if (!process.env.PINATA_JWT) {
+    throw new Error(
+      "PINATA_JWT is required to upload certificates to IPFS",
+    );
+  }
+  cachedClient = new PinataSDK({
+    pinataJwt: process.env.PINATA_JWT,
+    pinataGateway: process.env.GATEWAY_URL,
+  });
+  return cachedClient;
+}
+
+function sanitizeMetadataName(s) {
+  // Pinata's pinataMetadata.name field is a free-text label visible in the
+  // Pinata dashboard. Strip anything we wouldn't want a partner to see.
+  return String(s)
+    .replace(/\s+/g, "-")
+    .replace(/[^a-zA-Z0-9._-]/g, "")
+    .slice(0, 80)
+    .toLowerCase();
+}
+
+/**
+ * @param {object} params
+ * @param {Buffer} params.pdfBuffer
+ * @param {string} params.pdfFileName
+ * @param {string} params.title
+ * @param {string} [params.description]
+ * @param {string} params.studentWallet
+ * @param {string} params.certificateHash
+ * @param {string} params.issueDate                 YYYY-MM-DD
+ * @param {object} [params.client]                  Override for tests.
+ */
+async function uploadCertificate(params) {
+  const {
+    pdfBuffer, pdfFileName, title, description, studentWallet,
+    certificateHash, issueDate,
+  } = params;
+
+  if (!Buffer.isBuffer(pdfBuffer) || pdfBuffer.length === 0) {
+    throw new TypeError("uploadCertificate requires a non-empty pdfBuffer");
+  }
+  if (!title || typeof title !== "string") {
+    throw new TypeError("uploadCertificate requires a title");
+  }
+  if (!certificateHash || typeof certificateHash !== "string") {
+    throw new TypeError("uploadCertificate requires a certificateHash");
+  }
+
+  const pinata = params.client || getPinata();
+  const labelBase = sanitizeMetadataName(`${title}-${certificateHash.slice(0, 8)}`);
+
+  // 1) Pin the PDF.
+  const pdfBlob = new Blob([pdfBuffer], { type: "application/pdf" });
+  const pdfResp = await pinata.upload.public.file(pdfBlob, {
+    pinataMetadata: { name: `${labelBase}-pdf` },
+  });
+  const pdfCid = pdfResp && pdfResp.cid;
+  if (!pdfCid) {
+    throw new Error("Pinata did not return a cid for the PDF upload");
+  }
+
+  // 2) Build + pin the ERC-721 metadata.
+  const metadata = {
+    name: `Certificate: ${title}`,
+    description: description || "",
+    // For document-style NFTs both `image` (legacy) and `animation_url`
+    // (richer media) are honored by marketplaces. We use `image` since
+    // the existing repo convention does.
+    image: `ipfs://${pdfCid}`,
+    attributes: [
+      { trait_type: "Student",          value: studentWallet },
+      { trait_type: "Course",           value: title },
+      { trait_type: "Issue Date",       value: issueDate },
+      { trait_type: "Certificate Hash", value: certificateHash },
+    ],
+  };
+
+  const metaResp = await pinata.upload.public.json(metadata, {
+    pinataMetadata: { name: `${labelBase}-meta` },
+  });
+  const metadataCid = metaResp && metaResp.cid;
+  if (!metadataCid) {
+    throw new Error("Pinata did not return a cid for the metadata upload");
+  }
+
+  const tokenUri = `ipfs://${metadataCid}`;
+  console.log(`${LOG_PREFIX} pinned tokenUri=${tokenUri} (pdf=${pdfCid})`);
+  return { tokenUri, pdfCid, metadataCid };
+}
+
+function __resetForTests() {
+  cachedClient = null;
+}
+
+module.exports = {
+  uploadCertificate,
+  __resetForTests,
+};

--- a/backend/services/paymentService.js
+++ b/backend/services/paymentService.js
@@ -1,18 +1,28 @@
 // backend/services/paymentService.js
 //
-// SKELETON — on-chain $HACK payment verification.
-// Implementation pending. See documents/harjoot-integration-handoff.md.
+// DS Section 4 — on-chain $HACK payment verification + pricing.
 //
-// DS Section 4. Verifies that an educator paid the required amount of $HACK
-// (ERC-20 on Polygon) to the Treasury wallet before a certificate is issued.
-//
-// PRICING (DS decision 8, RESOLVED 2026-05-22). See the handoff doc for details.
+// PRICING (DS decision 8, RESOLVED 2026-05-22).
 // HackChain pays Harjoot $0.20/cert (config: HARJOOT_PRICE_USD_CENTS=20).
 // HackChain charges the educator $0.69/cert (config: USER_PRICE_USD_CENTS=69).
 // HackChain gross margin per cert = $0.49 (no commission; just the difference).
+//
+// Integer math is used end-to-end. Working unit is "HACK micro-dollars":
+//   1 HACK costs HACK_PRICE_USD_MICROS micro-dollars
+//   $1 = 100 cents = 100 * 10000 micros = 1_000_000 micros
+//   So:  cents-to-micros multiplier = 10_000.
+//
+// The returned amountHack is in WHOLE HACK tokens (not wei / base units).
+// The on-chain comparison in verifyHackPayment() multiplies this by the
+// token's decimals scale before comparing to the ERC-20 transfer value.
+
+const harjootConfig = require("../harjoot/config");
 
 const NOT_IMPLEMENTED =
   "Payment verification not implemented yet — see documents/harjoot-integration-handoff.md";
+
+const CENTS_PER_DOLLAR = 100;
+const MICROS_PER_CENT = 10_000;
 
 /**
  * DS Section 4 — verify a $HACK token payment on-chain.
@@ -24,7 +34,7 @@ const NOT_IMPLEMENTED =
  * @throws {Error} not implemented
  */
 async function verifyHackPayment(txHash, educatorWallet, expectedAmountHack) {
-  // TODO(impl): DS Section 4.
+  // TODO(impl): DS Section 4 (Phase 7c).
   //  - provider.getTransactionReceipt(txHash).
   //  - decode the ERC-20 Transfer event; validate: receipt status success,
   //    token address === HACK_TOKEN_ADDRESS, from === educatorWallet,
@@ -36,20 +46,61 @@ async function verifyHackPayment(txHash, educatorWallet, expectedAmountHack) {
 
 /**
  * DS Section 4 — compute how much $HACK an educator must pay per certificate.
- * Pure pricing helper. Use integer math to avoid floating-point errors.
+ * Pure pricing helper. Integer math only.
  *
- * @returns {{amountHack: bigint, harjootPriceUsdCents: number, commissionUsdCents: number}}
- * @throws {Error} not implemented
+ * Formula:
+ *   amountHack = USER_PRICE_USD_CENTS * MICROS_PER_CENT / HACK_PRICE_USD_MICROS
+ *
+ * With launch values (69 cents, 100 micros/HACK):
+ *   amountHack = 69 * 10_000 / 100 = 6900 HACK
+ *
+ * @returns {{
+ *   amountHack: bigint,
+ *   userPriceUsdCents: number,
+ *   harjootCostUsdCents: number,
+ *   grossMarginUsdCents: number,
+ *   treasuryAddress: string,
+ *   hackTokenAddress: string,
+ * }}
+ * @throws {Error} when integer division would lose precision (i.e. the
+ *   educator price is not an exact multiple of the HACK unit price).
  */
 function calculateMintPrice() {
-  // TODO(impl): DS decision 8 — pricing (RESOLVED 2026-05-22).
-  //  Config keys (see handoff doc): HARJOOT_PRICE_USD_CENTS (launch: 20),
-  //  USER_PRICE_USD_CENTS (launch: 69), HACK_PRICE_USD_MICROS (= 100).
-  //  Integer-math formula:
-  //    amountHack = USER_PRICE_USD_CENTS * 10000 / HACK_PRICE_USD_MICROS.
-  //  HackChain gross margin = USER_PRICE_USD_CENTS - HARJOOT_PRICE_USD_CENTS.
-  //  No commission — margin is the difference between user price and Harjoot cost.
-  throw new Error(NOT_IMPLEMENTED);
+  const { userPriceUsdCents, harjootCostUsdCents, hackPriceUsdMicros } = harjootConfig.pricing;
+  const { treasuryAddress, hackTokenAddress } = harjootConfig.chain;
+
+  // BigInt to avoid any silent precision loss for future larger prices.
+  const userPriceMicros = BigInt(userPriceUsdCents) * BigInt(MICROS_PER_CENT);
+  const hackUnitMicros  = BigInt(hackPriceUsdMicros);
+
+  if (hackUnitMicros === 0n) {
+    throw new Error("HACK_PRICE_USD_MICROS cannot be zero");
+  }
+  if (userPriceMicros % hackUnitMicros !== 0n) {
+    // Refuse to silently truncate; pricing must divide evenly. Catching this
+    // early makes mispriced configs fail fast at the precheck endpoint.
+    throw new Error(
+      `Pricing is not exact: ${userPriceUsdCents} cents / ${hackPriceUsdMicros} micros ` +
+        "does not divide evenly. Adjust USER_PRICE_USD_CENTS or HACK_PRICE_USD_MICROS.",
+    );
+  }
+
+  const amountHack = userPriceMicros / hackUnitMicros;
+
+  return {
+    amountHack,
+    userPriceUsdCents,
+    harjootCostUsdCents,
+    grossMarginUsdCents: userPriceUsdCents - harjootCostUsdCents,
+    treasuryAddress,
+    hackTokenAddress,
+  };
 }
 
-module.exports = { verifyHackPayment, calculateMintPrice };
+module.exports = {
+  verifyHackPayment,
+  calculateMintPrice,
+  // Exposed only for tests asserting against the conversion constants.
+  __CENTS_PER_DOLLAR: CENTS_PER_DOLLAR,
+  __MICROS_PER_CENT: MICROS_PER_CENT,
+};

--- a/backend/services/paymentService.js
+++ b/backend/services/paymentService.js
@@ -16,32 +16,204 @@
 // The on-chain comparison in verifyHackPayment() multiplies this by the
 // token's decimals scale before comparing to the ERC-20 transfer value.
 
+const { Interface } = require("ethers");
 const harjootConfig = require("../harjoot/config");
 
-const NOT_IMPLEMENTED =
-  "Payment verification not implemented yet — see documents/harjoot-integration-handoff.md";
-
+const LOG_PREFIX = "[verifyHackPayment]";
 const CENTS_PER_DOLLAR = 100;
 const MICROS_PER_CENT = 10_000;
+const TX_HASH_REGEX = /^0x[a-fA-F0-9]{64}$/;
+const WALLET_REGEX = /^0x[a-fA-F0-9]{40}$/;
+
+// Cached at module scope — the Interface is stateless and constructing
+// it on every call would be wasted work.
+const transferIface = new Interface([
+  "event Transfer(address indexed from, address indexed to, uint256 value)",
+]);
+const TRANSFER_TOPIC0 = transferIface.getEvent("Transfer").topicHash;
 
 /**
- * DS Section 4 — verify a $HACK token payment on-chain.
+ * DS Section 4 — verify a $HACK token payment on-chain and record it.
  *
- * @param {string}        txHash               ERC-20 transfer transaction hash.
- * @param {string}        educatorWallet       Expected sender (lowercased).
- * @param {string|bigint} expectedAmountHack   Minimum HACK amount required.
- * @returns {Promise<{paymentId: string, confirmed: boolean}>}
- * @throws {Error} not implemented
+ * Pulls the receipt for `txHash` via `provider`, validates that the
+ * educator transferred at least `expectedAmountHack` whole HACK to the
+ * configured treasury wallet, then persists a row in `payments`. The
+ * tx_hash unique constraint is the DB-level guarantee against replay.
+ *
+ * @param {object} params
+ * @param {object} params.models               db (db.Payment required).
+ * @param {object} params.provider             polygonProvider instance with
+ *                                             getTransactionReceipt(txHash).
+ * @param {string} params.txHash               0x-prefixed 32-byte tx hash.
+ * @param {string} params.expectedFrom         Educator wallet (any casing).
+ * @param {bigint} params.expectedAmountHack   Whole HACK units required.
+ * @param {string} params.purpose              e.g. "certificate_issuance".
+ * @param {{ harjootCostUsdCents: number, userPriceUsdCents: number }}
+ *         params.pricing                       Snapshot stored on the row.
+ * @param {object} [params.config]             Override harjoot/config (tests).
+ *
+ * @returns {Promise<
+ *   | { ok: true, payment: { id: number, txHash: string, fromWallet: string, amountHack: bigint } }
+ *   | { ok: false, reason: "TX_NOT_FOUND" | "TX_REVERTED" | "NO_HACK_TRANSFER"
+ *                       | "WRONG_RECIPIENT" | "WRONG_SENDER" | "INSUFFICIENT_AMOUNT" }
+ *   | { ok: false, reason: "REPLAY", existingPaymentId: number }
+ *   | { ok: false, reason: "RPC_ERROR", soft_failed: true, error: string }
+ * >}
  */
-async function verifyHackPayment(txHash, educatorWallet, expectedAmountHack) {
-  // TODO(impl): DS Section 4 (Phase 7c).
-  //  - provider.getTransactionReceipt(txHash).
-  //  - decode the ERC-20 Transfer event; validate: receipt status success,
-  //    token address === HACK_TOKEN_ADDRESS, from === educatorWallet,
-  //    to === TREASURY_ADDRESS, value >= expectedAmountHack.
-  //  - reject a txHash already recorded in `payments` (replay protection).
-  //  - on success, INSERT a row into the `payments` table and return its id.
-  throw new Error(NOT_IMPLEMENTED);
+async function verifyHackPayment(params) {
+  const { models, provider, txHash, expectedFrom, expectedAmountHack, purpose, pricing } = params;
+  const cfg = params.config || harjootConfig;
+
+  // ---- programmer-error guards ------------------------------------------------
+  if (!models || !models.Payment) {
+    throw new TypeError("verifyHackPayment requires { models.Payment }");
+  }
+  if (!provider || typeof provider.getTransactionReceipt !== "function") {
+    throw new TypeError("verifyHackPayment requires { provider.getTransactionReceipt }");
+  }
+  if (typeof txHash !== "string" || !TX_HASH_REGEX.test(txHash)) {
+    throw new TypeError("verifyHackPayment requires a 0x-prefixed 32-byte txHash");
+  }
+  if (typeof expectedFrom !== "string" || !WALLET_REGEX.test(expectedFrom)) {
+    throw new TypeError("verifyHackPayment requires a valid expectedFrom wallet");
+  }
+  if (typeof expectedAmountHack !== "bigint" || expectedAmountHack <= 0n) {
+    throw new TypeError("verifyHackPayment requires expectedAmountHack as a positive bigint");
+  }
+  if (!purpose || typeof purpose !== "string") {
+    throw new TypeError("verifyHackPayment requires a non-empty purpose");
+  }
+  if (!pricing || typeof pricing.harjootCostUsdCents !== "number" ||
+      typeof pricing.userPriceUsdCents !== "number") {
+    throw new TypeError(
+      "verifyHackPayment requires pricing { harjootCostUsdCents, userPriceUsdCents }",
+    );
+  }
+
+  const normalizedFrom = expectedFrom.toLowerCase();
+  const treasury = cfg.chain.treasuryAddress;
+  const hackToken = cfg.chain.hackTokenAddress;
+  const decimals = cfg.chain.hackTokenDecimals;
+
+  // ---- (1) replay pre-check ---------------------------------------------------
+  // Race window between this check and INSERT is closed by the unique
+  // constraint on tx_hash — caught further down.
+  const existing = await models.Payment.findOne({ where: { tx_hash: txHash } });
+  if (existing) {
+    return { ok: false, reason: "REPLAY", existingPaymentId: existing.id };
+  }
+
+  // ---- (2) fetch receipt ------------------------------------------------------
+  let receipt;
+  try {
+    receipt = await provider.getTransactionReceipt(txHash);
+  } catch (err) {
+    console.error(`${LOG_PREFIX} provider failure for ${txHash}: ${err.message || err}`);
+    return { ok: false, reason: "RPC_ERROR", soft_failed: true, error: err.message || String(err) };
+  }
+  if (!receipt) {
+    return { ok: false, reason: "TX_NOT_FOUND" };
+  }
+  // ethers v6: status is 1 (success) | 0 (revert). Anything else = treat as failed.
+  if (Number(receipt.status) !== 1) {
+    return { ok: false, reason: "TX_REVERTED" };
+  }
+
+  // ---- (3) scan Transfer logs for HACK movements ------------------------------
+  // Three buckets so we can pick the right error reason:
+  //   hackTransfers       — any Transfer event from the HACK token contract
+  //   hackToTreasury      — those whose `to` equals our treasury
+  //   matchedFromExpected — those whose `to` is treasury AND `from` is expected
+  let hackTransfers = 0;
+  let hackToTreasury = 0;
+  let summedFromExpected = 0n;
+
+  for (const log of receipt.logs || []) {
+    if (!log || !log.address || !Array.isArray(log.topics)) continue;
+    if (log.address.toLowerCase() !== hackToken) continue;
+    if (log.topics[0] !== TRANSFER_TOPIC0) continue;
+
+    let parsed;
+    try {
+      parsed = transferIface.parseLog({ topics: log.topics, data: log.data });
+    } catch {
+      // Malformed log — skip, do not crash the whole verification.
+      continue;
+    }
+    hackTransfers += 1;
+
+    const to = parsed.args.to.toLowerCase();
+    const from = parsed.args.from.toLowerCase();
+    const value = BigInt(parsed.args.value);
+
+    if (to !== treasury) continue;
+    hackToTreasury += 1;
+
+    if (from !== normalizedFrom) continue;
+    summedFromExpected += value;
+  }
+
+  if (hackTransfers === 0) {
+    return { ok: false, reason: "NO_HACK_TRANSFER" };
+  }
+  if (hackToTreasury === 0) {
+    return { ok: false, reason: "WRONG_RECIPIENT" };
+  }
+  if (summedFromExpected === 0n) {
+    return { ok: false, reason: "WRONG_SENDER" };
+  }
+
+  // ---- (4) amount check -------------------------------------------------------
+  // Compare in base units; convert expected (whole HACK) to base.
+  const scale = 10n ** BigInt(decimals);
+  const expectedBase = expectedAmountHack * scale;
+  if (summedFromExpected < expectedBase) {
+    return { ok: false, reason: "INSUFFICIENT_AMOUNT" };
+  }
+
+  // Actual whole HACK paid (truncating sub-token dust — `amount_hack` is BIGINT
+  // whole units per the model contract; precision below 1 HACK is irrelevant
+  // for accounting at $0.0001/HACK).
+  const actualAmountHack = summedFromExpected / scale;
+
+  // ---- (5) persist; race-safe via unique constraint on tx_hash ----------------
+  try {
+    const payment = await models.Payment.create({
+      tx_hash: txHash,
+      from_wallet: normalizedFrom,
+      amount_hack: actualAmountHack.toString(),
+      harjoot_price_usd: (pricing.harjootCostUsdCents / 100).toFixed(4),
+      user_price_usd: (pricing.userPriceUsdCents / 100).toFixed(4),
+      status: "confirmed",
+      purpose,
+    });
+
+    console.log(
+      `${LOG_PREFIX} confirmed payment_id=${payment.id} tx=${txHash} ` +
+        `from=${normalizedFrom} amount=${actualAmountHack} purpose=${purpose}`,
+    );
+    return {
+      ok: true,
+      payment: {
+        id: payment.id,
+        txHash,
+        fromWallet: normalizedFrom,
+        amountHack: actualAmountHack,
+      },
+    };
+  } catch (err) {
+    // SequelizeUniqueConstraintError — somebody else inserted the same
+    // tx_hash between our pre-check and INSERT. Treat as replay.
+    if (err && (err.name === "SequelizeUniqueConstraintError" || err.original?.code === "SQLITE_CONSTRAINT")) {
+      const conflict = await models.Payment.findOne({ where: { tx_hash: txHash } });
+      return {
+        ok: false,
+        reason: "REPLAY",
+        existingPaymentId: conflict ? conflict.id : null,
+      };
+    }
+    throw err; // unknown DB error — surface as 500
+  }
 }
 
 /**
@@ -103,4 +275,5 @@ module.exports = {
   // Exposed only for tests asserting against the conversion constants.
   __CENTS_PER_DOLLAR: CENTS_PER_DOLLAR,
   __MICROS_PER_CENT: MICROS_PER_CENT,
+  __TRANSFER_TOPIC0: TRANSFER_TOPIC0,
 };

--- a/backend/services/paymentService.js
+++ b/backend/services/paymentService.js
@@ -91,6 +91,12 @@ async function verifyHackPayment(params) {
   }
 
   const normalizedFrom = expectedFrom.toLowerCase();
+  // SECURITY: tx_hash is persisted and used as the replay-protection key.
+  // Postgres VARCHAR is case-sensitive, so without normalization "0xAB..."
+  // and "0xab..." (same hash on-chain) would both pass the UNIQUE
+  // constraint AND the pre-check, letting an attacker fund TWO certificates
+  // with a single on-chain payment. Always lowercase at the boundary.
+  const normalizedTxHash = txHash.toLowerCase();
   const treasury = cfg.chain.treasuryAddress;
   const hackToken = cfg.chain.hackTokenAddress;
   const decimals = cfg.chain.hackTokenDecimals;
@@ -98,17 +104,19 @@ async function verifyHackPayment(params) {
   // ---- (1) replay pre-check ---------------------------------------------------
   // Race window between this check and INSERT is closed by the unique
   // constraint on tx_hash — caught further down.
-  const existing = await models.Payment.findOne({ where: { tx_hash: txHash } });
+  const existing = await models.Payment.findOne({ where: { tx_hash: normalizedTxHash } });
   if (existing) {
     return { ok: false, reason: "REPLAY", existingPaymentId: existing.id };
   }
 
   // ---- (2) fetch receipt ------------------------------------------------------
+  // RPC nodes accept either casing, but log with the normalized value so a
+  // single tx_hash maps to a single log trail.
   let receipt;
   try {
-    receipt = await provider.getTransactionReceipt(txHash);
+    receipt = await provider.getTransactionReceipt(normalizedTxHash);
   } catch (err) {
-    console.error(`${LOG_PREFIX} provider failure for ${txHash}: ${err.message || err}`);
+    console.error(`${LOG_PREFIX} provider failure for ${normalizedTxHash}: ${err.message || err}`);
     return { ok: false, reason: "RPC_ERROR", soft_failed: true, error: err.message || String(err) };
   }
   if (!receipt) {
@@ -179,7 +187,7 @@ async function verifyHackPayment(params) {
   // ---- (5) persist; race-safe via unique constraint on tx_hash ----------------
   try {
     const payment = await models.Payment.create({
-      tx_hash: txHash,
+      tx_hash: normalizedTxHash,
       from_wallet: normalizedFrom,
       amount_hack: actualAmountHack.toString(),
       harjoot_price_usd: (pricing.harjootCostUsdCents / 100).toFixed(4),
@@ -189,14 +197,14 @@ async function verifyHackPayment(params) {
     });
 
     console.log(
-      `${LOG_PREFIX} confirmed payment_id=${payment.id} tx=${txHash} ` +
+      `${LOG_PREFIX} confirmed payment_id=${payment.id} tx=${normalizedTxHash} ` +
         `from=${normalizedFrom} amount=${actualAmountHack} purpose=${purpose}`,
     );
     return {
       ok: true,
       payment: {
         id: payment.id,
-        txHash,
+        txHash: normalizedTxHash,
         fromWallet: normalizedFrom,
         amountHack: actualAmountHack,
       },
@@ -205,7 +213,7 @@ async function verifyHackPayment(params) {
     // SequelizeUniqueConstraintError — somebody else inserted the same
     // tx_hash between our pre-check and INSERT. Treat as replay.
     if (err && (err.name === "SequelizeUniqueConstraintError" || err.original?.code === "SQLITE_CONSTRAINT")) {
-      const conflict = await models.Payment.findOne({ where: { tx_hash: txHash } });
+      const conflict = await models.Payment.findOne({ where: { tx_hash: normalizedTxHash } });
       return {
         ok: false,
         reason: "REPLAY",

--- a/backend/tests/healthHarjoot.test.js
+++ b/backend/tests/healthHarjoot.test.js
@@ -1,0 +1,96 @@
+// backend/tests/healthHarjoot.test.js
+//
+// Builds a mini Express app that mounts the same /health/harjoot handler
+// shape as index.js, so we exercise the getter wiring + the sanitization
+// of the cached partner payload without booting the full server.
+
+const express = require("express");
+const request = require("supertest");
+
+const checkPartnerHealth = require("../harjoot/usecases/checkPartnerHealth");
+
+function buildApp() {
+  const app = express();
+  app.get("/health/harjoot", (req, res) => {
+    const { getHealthState, getCachedPartnerInfo } = checkPartnerHealth;
+    const state = getHealthState();
+    const cached = getCachedPartnerInfo();
+    const partner = cached
+      ? { name: cached.name || null, status: cached.status || null }
+      : null;
+    return res.json({
+      ok: state.hasCache && !state.lastError,
+      hasCache: state.hasCache,
+      lastCheckedAt: state.lastCheckedAt,
+      lastError: state.lastError,
+      partner,
+    });
+  });
+  return app;
+}
+
+describe("GET /health/harjoot", () => {
+  beforeEach(() => {
+    checkPartnerHealth.__resetForTests();
+  });
+  afterAll(() => {
+    checkPartnerHealth.__resetForTests();
+  });
+
+  test("returns ok=false + hasCache=false when no check has run yet", async () => {
+    const res = await request(buildApp()).get("/health/harjoot");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: false,
+      hasCache: false,
+      lastCheckedAt: null,
+      lastError: null,
+      partner: null,
+    });
+  });
+
+  test("returns ok=true + sanitized partner payload after a successful check", async () => {
+    // Drive the cache via the real use case so we exercise the same
+    // getHealthState() / getCachedPartnerInfo() pair index.js calls.
+    const fakeClient = {
+      getPartnerInfo: jest.fn().mockResolvedValue({
+        name: "HackChain Partner Sandbox",
+        status: "active",
+        // Sensitive-ish fields that must NOT be echoed by /health/harjoot.
+        apiKey: "secret-do-not-leak",
+        internalId: "p_int_42",
+      }),
+    };
+    await checkPartnerHealth.checkPartnerHealth(fakeClient);
+
+    const res = await request(buildApp()).get("/health/harjoot");
+    expect(res.body.ok).toBe(true);
+    expect(res.body.hasCache).toBe(true);
+    expect(res.body.lastError).toBeNull();
+    expect(res.body.partner).toEqual({
+      name: "HackChain Partner Sandbox",
+      status: "active",
+    });
+    // Explicit anti-regression check — no sensitive fields anywhere in the body.
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toMatch(/secret-do-not-leak/);
+    expect(serialized).not.toMatch(/p_int_42/);
+  });
+
+  test("returns ok=false + lastError when the cached state shows a failed check", async () => {
+    const fakeClient = {
+      getPartnerInfo: jest.fn().mockRejectedValue(
+        Object.assign(new Error("Partner 401"), { name: "HarjootAuthError", code: "UNAUTHORIZED" }),
+      ),
+    };
+    await checkPartnerHealth.checkPartnerHealth(fakeClient);
+
+    const res = await request(buildApp()).get("/health/harjoot");
+    expect(res.body.ok).toBe(false);
+    expect(res.body.lastError).toEqual({
+      name: "HarjootAuthError",
+      message: "Partner 401",
+      code: "UNAUTHORIZED",
+    });
+  });
+});

--- a/backend/tests/setup-env.js
+++ b/backend/tests/setup-env.js
@@ -17,3 +17,8 @@ process.env.HARJOOT_API_BASE_URL    ||= "https://test.harjoot.local";
 process.env.HARJOOT_PARTNER_API_KEY ||= "test-partner-key";
 process.env.TREASURY_ADDRESS        ||= "0x0000000000000000000000000000000000000bee";
 process.env.HACK_TOKEN_ADDRESS      ||= "0x0000000000000000000000000000000000000ace";
+// Chain reads default to mock in test so anything that incidentally calls
+// the polygonProvider factory gets an in-process stub instead of trying to
+// hit a real RPC. Tests that exercise the real branch must opt in by
+// resetting modules and unsetting this var explicitly.
+process.env.CHAIN_USE_MOCK          ||= "true";

--- a/backend/tests/setup-env.js
+++ b/backend/tests/setup-env.js
@@ -15,3 +15,5 @@ process.env.JWT_SECRET              ||= "test_jwt_secret";
 process.env.REFRESH_SECRET          ||= "test_refresh_secret";
 process.env.HARJOOT_API_BASE_URL    ||= "https://test.harjoot.local";
 process.env.HARJOOT_PARTNER_API_KEY ||= "test-partner-key";
+process.env.TREASURY_ADDRESS        ||= "0x0000000000000000000000000000000000000bee";
+process.env.HACK_TOKEN_ADDRESS      ||= "0x0000000000000000000000000000000000000ace";

--- a/backend/workers/__tests__/treasuryForwarder.test.js
+++ b/backend/workers/__tests__/treasuryForwarder.test.js
@@ -1,0 +1,398 @@
+// backend/workers/__tests__/treasuryForwarder.test.js
+//
+// SQLite-in-memory exercises the real Sequelize Payment + TreasuryTransfer
+// + Certificate models. Strategy + harjootClient + usdtTransfer are mocked.
+
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+
+const { processTreasuryQueue } = require("../treasuryForwarder");
+
+const EDUCATOR = "0x1111111111111111111111111111111111111111";
+const STUDENT  = "0x2222222222222222222222222222222222222222";
+const HARJOOT_WALLET = "0x3333333333333333333333333333333333333333";
+
+describe("treasuryForwarder.processTreasuryQueue", () => {
+  let sequelize;
+  let User, Student, Issuer, Recruiter, UserSession;
+  let Certificate, Payment, TreasuryTransfer, TalentInvitation;
+  let models;
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    const { DataTypes } = SequelizePkg;
+
+    User = require("../../models/users")(sequelize, DataTypes);
+    Student = require("../../models/students")(sequelize, DataTypes);
+    Student.rawAttributes.wallet_address.unique = true;
+    Issuer = require("../../models/issuers")(sequelize, DataTypes);
+    Recruiter = require("../../models/recruiters")(sequelize, DataTypes);
+    UserSession = require("../../models/userSessions")(sequelize, DataTypes);
+    Certificate = require("../../models/certificates")(sequelize, DataTypes);
+    Payment = require("../../models/payments")(sequelize, DataTypes);
+    TreasuryTransfer = require("../../models/treasuryTransfers")(sequelize, DataTypes);
+    TalentInvitation = require("../../models/talentInvitations")(sequelize, DataTypes);
+
+    const all = { User, Student, Issuer, Recruiter, UserSession, Certificate, Payment, TreasuryTransfer, TalentInvitation };
+    Object.values(all).forEach((m) => m.associate && m.associate(all));
+
+    await sequelize.sync({ force: true });
+    models = { ...all, sequelize };
+
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    if (sequelize) await sequelize.close();
+  });
+
+  // -------------------------------------------------------------------------
+  // Seed helpers
+  // -------------------------------------------------------------------------
+
+  async function seedBaseUsers() {
+    await sequelize.sync({ force: true });
+    await User.create({
+      id: 1, wallet_address: EDUCATOR, role: "issuer", name: "Edu",
+      email: "edu@x.com", nonce: crypto.randomBytes(8).toString("hex"),
+      educator_approval_status: "approved",
+    });
+    await Issuer.create({ wallet_address: EDUCATOR, organization_name: "Acme" });
+    await User.create({
+      id: 2, wallet_address: STUDENT, role: "student", name: "Sty",
+      email: "sty@x.com", nonce: crypto.randomBytes(8).toString("hex"),
+    });
+    await Student.create({ wallet_address: STUDENT });
+  }
+
+  async function seedQueueRow({
+    txHashSuffix,
+    amountHack = 6900n,
+    verificationId = null,
+    status = "pending",
+  } = {}) {
+    const payment = await Payment.create({
+      tx_hash: "0x" + (txHashSuffix || crypto.randomBytes(32).toString("hex")),
+      from_wallet: EDUCATOR,
+      amount_hack: amountHack.toString(),
+      harjoot_price_usd: "0.2000",
+      user_price_usd: "0.6900",
+      status: "confirmed",
+      purpose: "certificate_issuance",
+    });
+    if (verificationId !== null) {
+      await Certificate.create({
+        issuer_wallet_address: EDUCATOR,
+        student_wallet_address: STUDENT,
+        title: "Cert",
+        certificate_hash: crypto.randomBytes(32).toString("hex"),
+        token_id: String(payment.id * 100),
+        issue_date: "2026-06-05",
+        payment_id: payment.id,
+        harjoot_verification_id: verificationId,
+        status: "issued",
+      });
+    }
+    const transfer = await TreasuryTransfer.create({
+      payment_id: payment.id,
+      amount_usdt_owed: "0.2000",
+      destination: "harjoot",
+      status,
+    });
+    return { payment, transfer };
+  }
+
+  function makeStrategy(behavior) {
+    return { convert: jest.fn().mockImplementation(behavior) };
+  }
+
+  function makeHarjootClient(notifyImpl) {
+    return {
+      notifyPayment: jest.fn().mockImplementation(notifyImpl || (async () => ({ ok: true }))),
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Empty queue
+  // -------------------------------------------------------------------------
+
+  test("returns processed=0 when the queue is empty", async () => {
+    await seedBaseUsers();
+    const strategy = makeStrategy(async () => ({ mode: "manual", awaitingManual: true }));
+    const result = await processTreasuryQueue({
+      models, strategy, harjootClient: makeHarjootClient(),
+    });
+    expect(result).toEqual({ processed: 0, mode: null });
+    expect(strategy.convert).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Manual happy path
+  // -------------------------------------------------------------------------
+
+  test("manual mode parks the batch as awaiting_manual_conversion", async () => {
+    await seedBaseUsers();
+    const r1 = await seedQueueRow({ txHashSuffix: "a".repeat(64), amountHack: 6900n });
+    const r2 = await seedQueueRow({ txHashSuffix: "b".repeat(64), amountHack: 6900n });
+
+    const strategy = makeStrategy(async ({ hackAmount }) => {
+      expect(hackAmount).toBe(13800n); // 6900 + 6900
+      return { mode: "manual", awaitingManual: true };
+    });
+    const harjootClient = makeHarjootClient();
+
+    const result = await processTreasuryQueue({ models, strategy, harjootClient });
+
+    expect(result).toEqual({ processed: 2, mode: "manual", awaitingManual: true });
+    const reloaded = await TreasuryTransfer.findAll({ order: [["id", "ASC"]] });
+    expect(reloaded.map((t) => t.status)).toEqual([
+      "awaiting_manual_conversion", "awaiting_manual_conversion",
+    ]);
+    // No USDT transfer or notify in manual mode.
+    expect(harjootClient.notifyPayment).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Strategy failures
+  // -------------------------------------------------------------------------
+
+  test("strategy throws -> rows marked failed; conversion error captured", async () => {
+    await seedBaseUsers();
+    await seedQueueRow({ txHashSuffix: "c".repeat(64) });
+
+    const strategy = makeStrategy(async () => { throw new Error("DEX router down"); });
+    const result = await processTreasuryQueue({
+      models, strategy, harjootClient: makeHarjootClient(),
+    });
+
+    expect(result.failed).toBe(true);
+    expect(result.error).toMatch(/STRATEGY_FAILED.*DEX router down/);
+    const row = await TreasuryTransfer.findOne();
+    expect(row.status).toBe("failed");
+    expect(row.error).toMatch(/STRATEGY_FAILED.*DEX router down/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Non-manual happy path
+  // -------------------------------------------------------------------------
+
+  test("non-manual mode transfers USDT, marks sent, calls notifyPayment with verificationIds", async () => {
+    await seedBaseUsers();
+    await seedQueueRow({ txHashSuffix: "d".repeat(64), verificationId: "ver_A" });
+    await seedQueueRow({ txHashSuffix: "e".repeat(64), verificationId: "ver_B" });
+
+    const strategy = makeStrategy(async () => ({
+      mode: "swap",
+      usdtAmount: 400000n, // 0.40 USDT in 6-decimals base units
+      txHash: "0xSWAP",
+      costs: { gasUsd: 0.05 },
+    }));
+    const usdtTransfer = jest.fn().mockResolvedValue({ txHash: "0xUSDTtx" });
+    const harjootClient = makeHarjootClient();
+
+    const result = await processTreasuryQueue({
+      models, strategy, harjootClient, usdtTransfer, harjootWallet: HARJOOT_WALLET,
+    });
+
+    expect(result.processed).toBe(2);
+    expect(result.mode).toBe("swap");
+    expect(result.usdtTxHash).toBe("0xUSDTtx");
+    expect(result.notifiedCount).toBe(2);
+
+    expect(usdtTransfer).toHaveBeenCalledWith({
+      usdtAmount: 400000n,
+      recipient: HARJOOT_WALLET,
+    });
+    expect(harjootClient.notifyPayment).toHaveBeenCalledWith(
+      ["ver_A", "ver_B"],
+      "0xUSDTtx",
+    );
+
+    const reloaded = await TreasuryTransfer.findAll({ order: [["id", "ASC"]] });
+    for (const r of reloaded) {
+      expect(r.status).toBe("sent");
+      expect(r.usdt_tx_hash).toBe("0xUSDTtx");
+      expect(r.sent_at).toBeInstanceOf(Date);
+    }
+  });
+
+  test("non-manual without usdtTransfer dep -> rows failed, no transfer attempted", async () => {
+    await seedBaseUsers();
+    await seedQueueRow({ txHashSuffix: "f".repeat(64) });
+
+    const strategy = makeStrategy(async () => ({
+      mode: "swap", usdtAmount: 200000n, txHash: "0xSWAP",
+    }));
+    const result = await processTreasuryQueue({
+      models, strategy, harjootClient: makeHarjootClient(),
+      // usdtTransfer + harjootWallet missing on purpose
+    });
+    expect(result.failed).toBe(true);
+    expect(result.error).toMatch(/STRATEGY_NEEDS_USDT_TRANSFER/);
+    const row = await TreasuryTransfer.findOne();
+    expect(row.status).toBe("failed");
+  });
+
+  test("non-manual without harjootWallet -> rows failed", async () => {
+    await seedBaseUsers();
+    await seedQueueRow({ txHashSuffix: "0".repeat(64) });
+
+    const strategy = makeStrategy(async () => ({
+      mode: "swap", usdtAmount: 200000n, txHash: "0xSWAP",
+    }));
+    const usdtTransfer = jest.fn();
+    const result = await processTreasuryQueue({
+      models, strategy, harjootClient: makeHarjootClient(), usdtTransfer,
+    });
+    expect(result.error).toMatch(/STRATEGY_NEEDS_HARJOOT_WALLET/);
+    expect(usdtTransfer).not.toHaveBeenCalled();
+  });
+
+  test("USDT transfer throws -> rows failed with USDT_TRANSFER_FAILED", async () => {
+    await seedBaseUsers();
+    await seedQueueRow({ txHashSuffix: "1".repeat(64) });
+
+    const strategy = makeStrategy(async () => ({
+      mode: "swap", usdtAmount: 200000n, txHash: "0xSWAP",
+    }));
+    const usdtTransfer = jest.fn().mockRejectedValue(new Error("RPC timeout"));
+    const result = await processTreasuryQueue({
+      models, strategy, harjootClient: makeHarjootClient(),
+      usdtTransfer, harjootWallet: HARJOOT_WALLET,
+    });
+
+    expect(result.failed).toBe(true);
+    expect(result.error).toMatch(/USDT_TRANSFER_FAILED.*RPC timeout/);
+    const row = await TreasuryTransfer.findOne();
+    expect(row.status).toBe("failed");
+  });
+
+  test("USDT transfer returns no txHash -> rows failed with USDT_TRANSFER_NO_HASH", async () => {
+    await seedBaseUsers();
+    await seedQueueRow({ txHashSuffix: "2".repeat(64) });
+
+    const strategy = makeStrategy(async () => ({
+      mode: "swap", usdtAmount: 200000n, txHash: "0xSWAP",
+    }));
+    const usdtTransfer = jest.fn().mockResolvedValue({ /* no txHash */ });
+    const result = await processTreasuryQueue({
+      models, strategy, harjootClient: makeHarjootClient(),
+      usdtTransfer, harjootWallet: HARJOOT_WALLET,
+    });
+
+    expect(result.failed).toBe(true);
+    expect(result.error).toMatch(/USDT_TRANSFER_NO_HASH/);
+  });
+
+  // -------------------------------------------------------------------------
+  // Notify failure DOES NOT undo USDT
+  // -------------------------------------------------------------------------
+
+  test("notifyPayment throws -> rows transition to sent_but_not_notified; USDT not reverted", async () => {
+    await seedBaseUsers();
+    await seedQueueRow({ txHashSuffix: "3".repeat(64), verificationId: "ver_X" });
+
+    const strategy = makeStrategy(async () => ({
+      mode: "swap", usdtAmount: 200000n, txHash: "0xSWAP",
+    }));
+    const usdtTransfer = jest.fn().mockResolvedValue({ txHash: "0xUSDT-good" });
+    const harjootClient = makeHarjootClient(async () => { throw new Error("Harjoot down"); });
+
+    const result = await processTreasuryQueue({
+      models, strategy, harjootClient, usdtTransfer, harjootWallet: HARJOOT_WALLET,
+    });
+
+    expect(result.notifyFailed).toBe(true);
+    expect(result.usdtTxHash).toBe("0xUSDT-good");
+    expect(result.error).toMatch(/Harjoot down/);
+
+    const row = await TreasuryTransfer.findOne();
+    expect(row.status).toBe("sent_but_not_notified");
+    expect(row.usdt_tx_hash).toBe("0xUSDT-good");
+    expect(row.error).toMatch(/NOTIFY_FAILED.*Harjoot down/);
+  });
+
+  // -------------------------------------------------------------------------
+  // batchSize
+  // -------------------------------------------------------------------------
+
+  test("respects batchSize so large queues are drained in chunks", async () => {
+    await seedBaseUsers();
+    // Seed 3 rows; batchSize=2 should only touch 2 this run.
+    await seedQueueRow({ txHashSuffix: "4".repeat(64) });
+    await seedQueueRow({ txHashSuffix: "5".repeat(64) });
+    await seedQueueRow({ txHashSuffix: "6".repeat(64) });
+
+    const strategy = makeStrategy(async () => ({ mode: "manual", awaitingManual: true }));
+    const result = await processTreasuryQueue({
+      models, strategy, harjootClient: makeHarjootClient(), batchSize: 2,
+    });
+    expect(result.processed).toBe(2);
+    const stillPending = await TreasuryTransfer.count({ where: { status: "pending" } });
+    expect(stillPending).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Skips rows that aren't pending
+  // -------------------------------------------------------------------------
+
+  test("does not touch rows whose status is already sent / failed / awaiting_manual_conversion", async () => {
+    await seedBaseUsers();
+    await seedQueueRow({ txHashSuffix: "7".repeat(64), status: "sent" });
+    await seedQueueRow({ txHashSuffix: "8".repeat(64), status: "failed" });
+    await seedQueueRow({ txHashSuffix: "9".repeat(64), status: "awaiting_manual_conversion" });
+
+    const strategy = makeStrategy(async () => ({ mode: "manual", awaitingManual: true }));
+    const result = await processTreasuryQueue({
+      models, strategy, harjootClient: makeHarjootClient(),
+    });
+    expect(result.processed).toBe(0);
+    expect(strategy.convert).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Verification id collection — tolerates rows without a certificate
+  // -------------------------------------------------------------------------
+
+  test("filters out missing/empty verificationIds before calling notifyPayment", async () => {
+    await seedBaseUsers();
+    await seedQueueRow({ txHashSuffix: "aa".repeat(32), verificationId: "ver_OK" });
+    await seedQueueRow({ txHashSuffix: "bb".repeat(32), verificationId: null }); // no cert
+    await seedQueueRow({ txHashSuffix: "cc".repeat(32), verificationId: "" });   // empty
+
+    const strategy = makeStrategy(async () => ({
+      mode: "swap", usdtAmount: 600000n, txHash: "0xSWAP",
+    }));
+    const usdtTransfer = jest.fn().mockResolvedValue({ txHash: "0xUSDT" });
+    const harjootClient = makeHarjootClient();
+
+    await processTreasuryQueue({
+      models, strategy, harjootClient, usdtTransfer, harjootWallet: HARJOOT_WALLET,
+    });
+
+    expect(harjootClient.notifyPayment).toHaveBeenCalledWith(["ver_OK"], "0xUSDT");
+  });
+
+  // -------------------------------------------------------------------------
+  // Programmer-error guards
+  // -------------------------------------------------------------------------
+
+  test("throws TypeError when strategy is missing", async () => {
+    await expect(
+      processTreasuryQueue({ models, harjootClient: makeHarjootClient() }),
+    ).rejects.toThrow(TypeError);
+  });
+
+  test("throws TypeError when harjootClient.notifyPayment is missing", async () => {
+    const strategy = makeStrategy(async () => ({ mode: "manual", awaitingManual: true }));
+    await expect(
+      processTreasuryQueue({ models, strategy, harjootClient: {} }),
+    ).rejects.toThrow(TypeError);
+  });
+});

--- a/backend/workers/__tests__/treasuryScheduler.test.js
+++ b/backend/workers/__tests__/treasuryScheduler.test.js
@@ -90,6 +90,7 @@ describe("runTreasuryForwarderOnce", () => {
         }),
       },
       Payment: {}, Certificate: {},
+      sequelize: { getDialect: () => "sqlite" },
     };
     const result = await runTreasuryForwarderOnce({
       models,
@@ -112,6 +113,7 @@ describe("runTreasuryForwarderOnce", () => {
         }),
       },
       Payment: {}, Certificate: {},
+      sequelize: { getDialect: () => "sqlite" },
     };
     const result = await runTreasuryForwarderOnce({
       models,
@@ -184,11 +186,14 @@ describe("scheduleTreasuryForwarder", () => {
   }
 
   // Empty-queue models so the underlying tick is cheap.
+  // Includes a fake sequelize so the withPgAdvisoryLock wrap sees a non-
+  // postgres dialect and no-ops the lock.
   function emptyModels() {
     return {
       TreasuryTransfer: { findAll: jest.fn().mockResolvedValue([]) },
       Payment: {},
       Certificate: {},
+      sequelize: { getDialect: () => "sqlite" },
     };
   }
 
@@ -242,6 +247,7 @@ describe("scheduleTreasuryForwarder", () => {
         findAll: jest.fn().mockImplementation(() => blocking.then(() => [])),
       },
       Payment: {}, Certificate: {},
+      sequelize: { getDialect: () => "sqlite" },
     };
 
     scheduleTreasuryForwarder({
@@ -266,6 +272,61 @@ describe("scheduleTreasuryForwarder", () => {
     // Subsequent tick after #1 finished can run normally again.
     await tick();
     expect(models.TreasuryTransfer.findAll).toHaveBeenCalledTimes(2);
+  });
+
+  test("postgres dialect: tick issues pg_try_advisory_lock + pg_advisory_unlock around the work", async () => {
+    const cron = makeFakeCron();
+    const sqlCalls = [];
+    const sequelize = {
+      getDialect: () => "postgres",
+      query: jest.fn().mockImplementation(async (sql) => {
+        sqlCalls.push(sql);
+        if (sql.includes("pg_try_advisory_lock")) return [[{ acquired: true }], {}];
+        if (sql.includes("pg_advisory_unlock"))    return [[{ pg_advisory_unlock: true }], {}];
+        return [[], {}];
+      }),
+    };
+    const models = {
+      TreasuryTransfer: { findAll: jest.fn().mockResolvedValue([]) },
+      Payment: {}, Certificate: {},
+      sequelize,
+    };
+    scheduleTreasuryForwarder({
+      cron, models,
+      selectStrategy: () => ({ mode: "manual", strategy: { convert: jest.fn() } }),
+      harjootClient: { notifyPayment: jest.fn() },
+    });
+
+    await cron.ticks[0].fn();
+
+    expect(sqlCalls.some((s) => s.includes("pg_try_advisory_lock"))).toBe(true);
+    expect(sqlCalls.some((s) => s.includes("pg_advisory_unlock"))).toBe(true);
+    expect(models.TreasuryTransfer.findAll).toHaveBeenCalledTimes(1);
+  });
+
+  test("postgres dialect: when another instance holds the lock, the tick skips the work", async () => {
+    const cron = makeFakeCron();
+    const sequelize = {
+      getDialect: () => "postgres",
+      query: jest.fn().mockImplementation(async (sql) => {
+        if (sql.includes("pg_try_advisory_lock")) return [[{ acquired: false }], {}];
+        return [[], {}];
+      }),
+    };
+    const models = {
+      TreasuryTransfer: { findAll: jest.fn().mockResolvedValue([]) },
+      Payment: {}, Certificate: {},
+      sequelize,
+    };
+    scheduleTreasuryForwarder({
+      cron, models,
+      selectStrategy: () => ({ mode: "manual", strategy: { convert: jest.fn() } }),
+      harjootClient: { notifyPayment: jest.fn() },
+    });
+
+    await cron.ticks[0].fn();
+    // Work NOT executed because the advisory lock was already held.
+    expect(models.TreasuryTransfer.findAll).not.toHaveBeenCalled();
   });
 
   test("tick swallows runTreasuryForwarderOnce rejection so the cron loop survives", async () => {

--- a/backend/workers/__tests__/treasuryScheduler.test.js
+++ b/backend/workers/__tests__/treasuryScheduler.test.js
@@ -12,6 +12,7 @@ const {
   scheduleTreasuryForwarder,
   __DEFAULT_CRON_EXPRESSION,
 } = require("../treasuryForwarder");
+const { getCorrelationId } = require("../../lib/correlationContext");
 
 beforeAll(() => {
   jest.spyOn(console, "log").mockImplementation(() => {});
@@ -49,7 +50,9 @@ describe("runTreasuryForwarderOnce", () => {
     expect(models.TreasuryTransfer.findAll).toHaveBeenCalledTimes(1);
     // Empty queue -> strategy.convert never invoked.
     expect(strategy.convert).not.toHaveBeenCalled();
-    expect(result).toEqual({ processed: 0, mode: null });
+    expect(result).toMatchObject({ processed: 0, mode: null });
+    // 9a adds correlation_id propagation; just sanity-check it's a string.
+    expect(typeof result.correlationId).toBe("string");
   });
 
   test("strategy factory throws (unknown mode) -> soft fail, no crash", async () => {
@@ -75,6 +78,49 @@ describe("runTreasuryForwarderOnce", () => {
 
     expect(result.failed).toBe(true);
     expect(result.error).toMatch(/convert/);
+  });
+
+  test("generates a cron-<uuid> correlation id and makes it readable from getCorrelationId during the tick", async () => {
+    let observedDuringTick;
+    const models = {
+      TreasuryTransfer: {
+        findAll: jest.fn().mockImplementation(async () => {
+          observedDuringTick = getCorrelationId();
+          return [];
+        }),
+      },
+      Payment: {}, Certificate: {},
+    };
+    const result = await runTreasuryForwarderOnce({
+      models,
+      selectStrategy: () => ({ mode: "manual", strategy: { convert: jest.fn() } }),
+      harjootClient: { notifyPayment: jest.fn() },
+    });
+    expect(observedDuringTick).toMatch(/^cron-[0-9a-f-]{36}$/);
+    expect(result.correlationId).toBe(observedDuringTick);
+    // Context is cleared after the tick ends.
+    expect(getCorrelationId()).toBeUndefined();
+  });
+
+  test("honors an explicit options.correlationId for ops-triggered runs", async () => {
+    let observed;
+    const models = {
+      TreasuryTransfer: {
+        findAll: jest.fn().mockImplementation(async () => {
+          observed = getCorrelationId();
+          return [];
+        }),
+      },
+      Payment: {}, Certificate: {},
+    };
+    const result = await runTreasuryForwarderOnce({
+      models,
+      correlationId: "ops-manual-drain-2026-06-05",
+      selectStrategy: () => ({ mode: "manual", strategy: { convert: jest.fn() } }),
+      harjootClient: { notifyPayment: jest.fn() },
+    });
+    expect(observed).toBe("ops-manual-drain-2026-06-05");
+    expect(result.correlationId).toBe("ops-manual-drain-2026-06-05");
   });
 
   test("forwards usdtTransfer + harjootWallet + batchSize to processTreasuryQueue", async () => {

--- a/backend/workers/__tests__/treasuryScheduler.test.js
+++ b/backend/workers/__tests__/treasuryScheduler.test.js
@@ -1,0 +1,242 @@
+// backend/workers/__tests__/treasuryScheduler.test.js
+//
+// Two surfaces under test:
+//   runTreasuryForwarderOnce — pure invocation, dep wiring, soft-fail on
+//     a misconfigured strategy or a worker exception.
+//   scheduleTreasuryForwarder — cron registration with default expression,
+//     in-process lock that drops overlapping ticks, no work-loop crash
+//     when the tick rejects.
+
+const {
+  runTreasuryForwarderOnce,
+  scheduleTreasuryForwarder,
+  __DEFAULT_CRON_EXPRESSION,
+} = require("../treasuryForwarder");
+
+beforeAll(() => {
+  jest.spyOn(console, "log").mockImplementation(() => {});
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+  jest.spyOn(console, "error").mockImplementation(() => {});
+});
+afterAll(() => jest.restoreAllMocks());
+
+// ---------------------------------------------------------------------------
+// runTreasuryForwarderOnce — pure tick
+// ---------------------------------------------------------------------------
+
+describe("runTreasuryForwarderOnce", () => {
+  // Minimal DB stand-in: only the surface processTreasuryQueue actually
+  // touches when the queue is empty (findAll returns []).
+  function makeEmptyModels() {
+    return {
+      TreasuryTransfer: { findAll: jest.fn().mockResolvedValue([]) },
+      Payment: {},
+      Certificate: {},
+    };
+  }
+
+  test("happy path: routes selectStrategy + models + harjootClient into the worker; empty queue -> processed=0", async () => {
+    const models = makeEmptyModels();
+    const strategy = { convert: jest.fn() };
+    const selectStrategy = jest.fn().mockReturnValue({ mode: "manual", strategy });
+    const harjootClient = { notifyPayment: jest.fn() };
+
+    const result = await runTreasuryForwarderOnce({
+      models, selectStrategy, harjootClient,
+    });
+
+    expect(selectStrategy).toHaveBeenCalledTimes(1);
+    expect(models.TreasuryTransfer.findAll).toHaveBeenCalledTimes(1);
+    // Empty queue -> strategy.convert never invoked.
+    expect(strategy.convert).not.toHaveBeenCalled();
+    expect(result).toEqual({ processed: 0, mode: null });
+  });
+
+  test("strategy factory throws (unknown mode) -> soft fail, no crash", async () => {
+    const result = await runTreasuryForwarderOnce({
+      models: makeEmptyModels(),
+      harjootClient: { notifyPayment: jest.fn() },
+      selectStrategy: () => { throw new Error("Unknown TREASURY_CONVERSION_MODE=manaul"); },
+    });
+
+    expect(result.failed).toBe(true);
+    expect(result.error).toMatch(/Unknown TREASURY_CONVERSION_MODE/);
+  });
+
+  test("processTreasuryQueue dep TypeError -> soft fail (logged, not rethrown)", async () => {
+    // Force the worker to throw TypeError by handing it a malformed
+    // strategy object.
+    const result = await runTreasuryForwarderOnce({
+      models: makeEmptyModels(),
+      harjootClient: { notifyPayment: jest.fn() },
+      // Strategy without convert() — processTreasuryQueue assertDeps throws TypeError.
+      selectStrategy: () => ({ mode: "manual", strategy: {} }),
+    });
+
+    expect(result.failed).toBe(true);
+    expect(result.error).toMatch(/convert/);
+  });
+
+  test("forwards usdtTransfer + harjootWallet + batchSize to processTreasuryQueue", async () => {
+    // Use a non-empty queue so the strategy actually runs, then assert
+    // on the params the worker received via spies.
+    const fakeRow = {
+      id: 1,
+      Payment: { amount_hack: "6900", Certificate: { harjoot_verification_id: "ver_z" } },
+    };
+    const models = {
+      TreasuryTransfer: {
+        findAll: jest.fn().mockResolvedValue([fakeRow]),
+        update: jest.fn().mockResolvedValue([1]),
+      },
+      Payment: {},
+      Certificate: {},
+    };
+    const strategy = {
+      convert: jest.fn().mockResolvedValue({
+        mode: "swap", usdtAmount: 200000n, txHash: "0xSWAP",
+      }),
+    };
+    const usdtTransfer = jest.fn().mockResolvedValue({ txHash: "0xUSDT" });
+    const harjootClient = { notifyPayment: jest.fn().mockResolvedValue({ ok: true }) };
+
+    const result = await runTreasuryForwarderOnce({
+      models,
+      selectStrategy: () => ({ mode: "swap", strategy }),
+      harjootClient,
+      usdtTransfer,
+      harjootWallet: "0x4444444444444444444444444444444444444444",
+      batchSize: 25,
+    });
+
+    expect(models.TreasuryTransfer.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 25 }),
+    );
+    expect(usdtTransfer).toHaveBeenCalledWith({
+      usdtAmount: 200000n,
+      recipient: "0x4444444444444444444444444444444444444444",
+    });
+    expect(result.usdtTxHash).toBe("0xUSDT");
+    expect(result.notifiedCount).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scheduleTreasuryForwarder — cron wiring + lock
+// ---------------------------------------------------------------------------
+
+describe("scheduleTreasuryForwarder", () => {
+  // Fake cron mirrors node-cron's schedule(expr, fn) -> { stop } surface.
+  function makeFakeCron() {
+    const ticks = [];
+    const fakeTask = { stop: jest.fn() };
+    const schedule = jest.fn().mockImplementation((expr, fn) => {
+      ticks.push({ expr, fn });
+      return fakeTask;
+    });
+    return { schedule, ticks, fakeTask };
+  }
+
+  // Empty-queue models so the underlying tick is cheap.
+  function emptyModels() {
+    return {
+      TreasuryTransfer: { findAll: jest.fn().mockResolvedValue([]) },
+      Payment: {},
+      Certificate: {},
+    };
+  }
+
+  test("registers a cron with the default expression and returns the task", () => {
+    const cron = makeFakeCron();
+    const task = scheduleTreasuryForwarder({
+      cron, models: emptyModels(),
+      selectStrategy: () => ({ mode: "manual", strategy: { convert: jest.fn() } }),
+      harjootClient: { notifyPayment: jest.fn() },
+    });
+
+    expect(cron.schedule).toHaveBeenCalledTimes(1);
+    expect(cron.schedule.mock.calls[0][0]).toBe(__DEFAULT_CRON_EXPRESSION);
+    expect(__DEFAULT_CRON_EXPRESSION).toBe("*/10 * * * *");
+    expect(task).toBe(cron.fakeTask);
+  });
+
+  test("honors a custom cronExpression", () => {
+    const cron = makeFakeCron();
+    scheduleTreasuryForwarder({
+      cron, cronExpression: "*/5 * * * *",
+      models: emptyModels(),
+      selectStrategy: () => ({ mode: "manual", strategy: { convert: jest.fn() } }),
+      harjootClient: { notifyPayment: jest.fn() },
+    });
+    expect(cron.schedule.mock.calls[0][0]).toBe("*/5 * * * *");
+  });
+
+  test("tick wraps runTreasuryForwarderOnce; first tick runs to completion", async () => {
+    const cron = makeFakeCron();
+    const models = emptyModels();
+    scheduleTreasuryForwarder({
+      cron, models,
+      selectStrategy: () => ({ mode: "manual", strategy: { convert: jest.fn() } }),
+      harjootClient: { notifyPayment: jest.fn() },
+    });
+
+    // Invoke the registered tick directly.
+    await cron.ticks[0].fn();
+    expect(models.TreasuryTransfer.findAll).toHaveBeenCalledTimes(1);
+  });
+
+  test("in-process lock drops overlapping ticks", async () => {
+    const cron = makeFakeCron();
+
+    // Block the queue read until we release it manually.
+    let release;
+    const blocking = new Promise((r) => { release = r; });
+    const models = {
+      TreasuryTransfer: {
+        findAll: jest.fn().mockImplementation(() => blocking.then(() => [])),
+      },
+      Payment: {}, Certificate: {},
+    };
+
+    scheduleTreasuryForwarder({
+      cron, models,
+      selectStrategy: () => ({ mode: "manual", strategy: { convert: jest.fn() } }),
+      harjootClient: { notifyPayment: jest.fn() },
+    });
+
+    const tick = cron.ticks[0].fn;
+    // Tick #1 starts and is blocked on the queue read.
+    const t1 = tick();
+    // Tick #2 fires while #1 is still in-flight -> must short-circuit.
+    const t2 = tick();
+    await t2; // resolves immediately because of the lock
+
+    expect(models.TreasuryTransfer.findAll).toHaveBeenCalledTimes(1);
+    // Release tick #1.
+    release();
+    await t1;
+    expect(models.TreasuryTransfer.findAll).toHaveBeenCalledTimes(1);
+
+    // Subsequent tick after #1 finished can run normally again.
+    await tick();
+    expect(models.TreasuryTransfer.findAll).toHaveBeenCalledTimes(2);
+  });
+
+  test("tick swallows runTreasuryForwarderOnce rejection so the cron loop survives", async () => {
+    const cron = makeFakeCron();
+    // selectStrategy that throws on each call -> runOnce catches + soft-fails.
+    let callCount = 0;
+    scheduleTreasuryForwarder({
+      cron,
+      models: emptyModels(),
+      selectStrategy: () => { callCount += 1; throw new Error("bad config"); },
+      harjootClient: { notifyPayment: jest.fn() },
+    });
+
+    const tick = cron.ticks[0].fn;
+    // Multiple ticks back-to-back should not throw.
+    await expect(tick()).resolves.toBeUndefined();
+    await expect(tick()).resolves.toBeUndefined();
+    expect(callCount).toBe(2);
+  });
+});

--- a/backend/workers/treasuryForwarder.js
+++ b/backend/workers/treasuryForwarder.js
@@ -1,49 +1,227 @@
 // backend/workers/treasuryForwarder.js
 //
-// SKELETON — async Treasury -> Harjoot settlement worker.
-// Implementation pending. See documents/harjoot-integration-handoff.md.
+// DS Section 13 — async worker that drains `treasury_transfers_queue`,
+// applies the configured HACK -> USDT conversion strategy, and (for the
+// non-manual paths) transfers USDT to Harjoot + notifies them.
 //
-// DS Section 13. Drains the `treasury_transfers_queue` table, converts the
-// collected $HACK to USDT, sends USDT to Harjoot, and notifies Harjoot.
-// Runs as a background job (cron / queue consumer), NOT in any HTTP request.
+// Runs on a cron schedule from index.js. NEVER call this inside an HTTP
+// request handler — long-running tx waits would tie up Express workers.
 //
-// OPEN DECISIONS:
-//   - DS TODO 3: the HACK -> USDT conversion mechanism (manual / DEX swap /
-//     burn-redeem) is a blockchain-developer decision. Treat the conversion
-//     as a pluggable step so only that step changes once decided.
-//   - DS TODO 6: the Harjoot payment-notification endpoint is not finalized.
+// State machine for `treasury_transfers_queue.status`:
+//   pending
+//     |
+//     |---> awaiting_manual_conversion   (manual strategy parked it)
+//     |---> failed                       (strategy or USDT transfer threw)
+//     |---> sent                         (USDT transferred + Harjoot notified)
+//     |---> sent_but_not_notified        (USDT transferred; notify threw)
+//
+// The state machine intentionally has no transition out of `failed` or
+// `awaiting_manual_conversion` — those require operator intervention
+// (a dedicated /admin endpoint, to be added later).
+
+const LOG_PREFIX = "[treasuryForwarder]";
+
+const DEFAULT_BATCH_SIZE = 50;
+
+function assertDeps({ models, strategy, harjootClient }) {
+  if (!models || !models.TreasuryTransfer || !models.Payment) {
+    throw new TypeError(
+      "processTreasuryQueue requires { models.{TreasuryTransfer, Payment} }",
+    );
+  }
+  if (!strategy || typeof strategy.convert !== "function") {
+    throw new TypeError("processTreasuryQueue requires strategy.convert");
+  }
+  if (!harjootClient || typeof harjootClient.notifyPayment !== "function") {
+    throw new TypeError("processTreasuryQueue requires harjootClient.notifyPayment");
+  }
+}
+
+async function markRowsStatus(models, rowIds, fields) {
+  if (rowIds.length === 0) return;
+  await models.TreasuryTransfer.update(fields, {
+    where: { id: rowIds },
+  });
+}
+
+/**
+ * Drain one batch of pending treasury transfers.
+ *
+ * @param {object} params
+ * @param {object} params.models          db (Payment, TreasuryTransfer,
+ *                                        Certificate optional for verification ids).
+ * @param {object} params.strategy        IConversionStrategy ({ convert }).
+ * @param {object} params.harjootClient   Must expose notifyPayment(verificationIds, txHash).
+ * @param {function} [params.usdtTransfer] Async ({usdtAmount, recipient}) => {txHash}.
+ *                                        Required for non-manual strategies.
+ * @param {string}  [params.harjootWallet] Required for non-manual strategies.
+ * @param {number}  [params.batchSize]    Default 50.
+ *
+ * @returns {Promise<{
+ *   processed: number,
+ *   mode: "manual"|"swap"|"burn_redeem"|null,
+ *   awaitingManual?: boolean,
+ *   usdtTxHash?: string,
+ *   failed?: boolean,
+ *   error?: string,
+ * }>}
+ */
+async function processTreasuryQueue(params) {
+  const { models, strategy, harjootClient } = params;
+  const batchSize = params.batchSize || DEFAULT_BATCH_SIZE;
+  assertDeps(params);
+
+  // ---- 1. Fetch pending rows + linked payment (+ optional certificate) -----
+  const include = [{
+    model: models.Payment,
+    required: true,
+    include: models.Certificate
+      ? [{ model: models.Certificate, required: false }]
+      : [],
+  }];
+  const rows = await models.TreasuryTransfer.findAll({
+    where: { status: "pending" },
+    include,
+    limit: batchSize,
+    order: [["created_at", "ASC"]],
+  });
+
+  if (rows.length === 0) {
+    return { processed: 0, mode: null };
+  }
+  const rowIds = rows.map((r) => r.id);
+
+  // ---- 2. Aggregate HACK total ---------------------------------------------
+  let hackTotal = 0n;
+  for (const r of rows) {
+    // amount_hack stored as BIGINT, read back as string in Sequelize.
+    hackTotal += BigInt(r.Payment.amount_hack);
+  }
+
+  console.log(
+    `${LOG_PREFIX} draining batch size=${rows.length} hack_total=${hackTotal}`,
+  );
+
+  // ---- 3. Strategy.convert -------------------------------------------------
+  let conversion;
+  try {
+    conversion = await strategy.convert({ hackAmount: hackTotal });
+  } catch (err) {
+    const errorMsg = `STRATEGY_FAILED: ${err.message || err}`;
+    console.error(`${LOG_PREFIX} ${errorMsg}`);
+    await markRowsStatus(models, rowIds, { status: "failed", error: errorMsg });
+    return { processed: rows.length, mode: null, failed: true, error: errorMsg };
+  }
+
+  // ---- 4. Manual path: park the batch and exit -----------------------------
+  if (conversion.awaitingManual) {
+    await markRowsStatus(models, rowIds, { status: "awaiting_manual_conversion" });
+    console.log(
+      `${LOG_PREFIX} batch parked awaiting_manual_conversion count=${rows.length}`,
+    );
+    return {
+      processed: rows.length,
+      mode: conversion.mode,
+      awaitingManual: true,
+    };
+  }
+
+  // ---- 5. Non-manual path: USDT transfer + notify ---------------------------
+  // Validate deps lazily — manual mode doesn't need usdtTransfer / wallet.
+  const { usdtTransfer, harjootWallet } = params;
+  if (typeof usdtTransfer !== "function") {
+    const errorMsg = "STRATEGY_NEEDS_USDT_TRANSFER: non-manual strategy returned a result but usdtTransfer dep is missing";
+    console.error(`${LOG_PREFIX} ${errorMsg}`);
+    await markRowsStatus(models, rowIds, { status: "failed", error: errorMsg });
+    return { processed: rows.length, mode: conversion.mode, failed: true, error: errorMsg };
+  }
+  if (!harjootWallet) {
+    const errorMsg = "STRATEGY_NEEDS_HARJOOT_WALLET: non-manual strategy returned a result but harjootWallet dep is missing";
+    console.error(`${LOG_PREFIX} ${errorMsg}`);
+    await markRowsStatus(models, rowIds, { status: "failed", error: errorMsg });
+    return { processed: rows.length, mode: conversion.mode, failed: true, error: errorMsg };
+  }
+
+  let transferResult;
+  try {
+    transferResult = await usdtTransfer({
+      usdtAmount: conversion.usdtAmount,
+      recipient: harjootWallet,
+    });
+  } catch (err) {
+    const errorMsg = `USDT_TRANSFER_FAILED: ${err.message || err}`;
+    console.error(`${LOG_PREFIX} ${errorMsg}`);
+    await markRowsStatus(models, rowIds, { status: "failed", error: errorMsg });
+    return { processed: rows.length, mode: conversion.mode, failed: true, error: errorMsg };
+  }
+
+  const usdtTxHash = transferResult && transferResult.txHash;
+  if (!usdtTxHash) {
+    const errorMsg = "USDT_TRANSFER_NO_HASH: usdtTransfer returned without a txHash";
+    console.error(`${LOG_PREFIX} ${errorMsg}`);
+    await markRowsStatus(models, rowIds, { status: "failed", error: errorMsg });
+    return { processed: rows.length, mode: conversion.mode, failed: true, error: errorMsg };
+  }
+
+  // ---- 6. Mark rows sent ----------------------------------------------------
+  const sentAt = new Date();
+  await markRowsStatus(models, rowIds, {
+    status: "sent",
+    usdt_tx_hash: usdtTxHash,
+    sent_at: sentAt,
+  });
+
+  // ---- 7. Notify Harjoot. Failure here does NOT undo the on-chain transfer.
+  const verificationIds = rows
+    .map((r) => r.Payment && r.Payment.Certificate && r.Payment.Certificate.harjoot_verification_id)
+    .filter((id) => typeof id === "string" && id.length > 0);
+
+  try {
+    await harjootClient.notifyPayment(verificationIds, usdtTxHash);
+    console.log(
+      `${LOG_PREFIX} batch sent count=${rows.length} usdt_tx=${usdtTxHash} ` +
+        `notified=${verificationIds.length}`,
+    );
+    return {
+      processed: rows.length,
+      mode: conversion.mode,
+      usdtTxHash,
+      notifiedCount: verificationIds.length,
+    };
+  } catch (err) {
+    console.error(
+      `${LOG_PREFIX} notifyPayment failed; on-chain transfer already done: ${err.message || err}`,
+    );
+    // Transition rows to sent_but_not_notified so ops can reconcile.
+    await markRowsStatus(models, rowIds, {
+      status: "sent_but_not_notified",
+      error: `NOTIFY_FAILED: ${err.message || err}`,
+    });
+    return {
+      processed: rows.length,
+      mode: conversion.mode,
+      usdtTxHash,
+      notifyFailed: true,
+      error: err.message || String(err),
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scheduler — wired in Phase 8c
+// ---------------------------------------------------------------------------
 
 const NOT_IMPLEMENTED =
-  "Treasury forwarder not implemented yet — see documents/harjoot-integration-handoff.md";
+  "scheduleTreasuryForwarder is wired in Phase 8c; not available yet";
 
-/**
- * DS Section 13 — process one batch of pending treasury transfers.
- *
- * @returns {Promise<{processed: number, usdtTxHash: string|null}>}
- * @throws {Error} not implemented
- */
-async function processTreasuryQueue() {
-  // TODO(impl): DS Section 13.
-  //  1. SELECT pending rows FROM treasury_transfers_queue (LIMIT batch_size).
-  //  2. Stage 1 — convert HACK to USDT (pluggable step; DS TODO 3).
-  //  3. Stage 2 — transfer USDT to the Harjoot wallet.
-  //  4. On success: mark rows "sent" and call harjootService.notifyPayment().
-  //  5. On failure: mark rows "failed" and alert ops.
+function scheduleTreasuryForwarder(_options = {}) {
+  // TODO(Phase 8c): cron.schedule("*/10 * * * *", processTreasuryQueue) with
+  // injected deps. Single-instance lock so multiple boxes don't race.
   throw new Error(NOT_IMPLEMENTED);
 }
 
-/**
- * Register the worker on a cron schedule. Call once from index.js after the
- * server starts (mirrors the existing session-purge cron).
- *
- * @param {object} [options]
- * @param {string} [options.cronExpression]  Cron expression; defaults to every 10 minutes.
- * @throws {Error} not implemented
- */
-function scheduleTreasuryForwarder(options = {}) {
-  // TODO(impl): schedule processTreasuryQueue() with node-cron.
-  // Example: cron.schedule(options.cronExpression || "*/10 * * * *", processTreasuryQueue)
-  throw new Error(NOT_IMPLEMENTED);
-}
-
-module.exports = { processTreasuryQueue, scheduleTreasuryForwarder };
+module.exports = {
+  processTreasuryQueue,
+  scheduleTreasuryForwarder,
+  __DEFAULT_BATCH_SIZE: DEFAULT_BATCH_SIZE,
+};

--- a/backend/workers/treasuryForwarder.js
+++ b/backend/workers/treasuryForwarder.js
@@ -6,6 +6,9 @@
 //
 // Runs on a cron schedule from index.js. NEVER call this inside an HTTP
 // request handler — long-running tx waits would tie up Express workers.
+
+const crypto = require("crypto");
+const { runWithCorrelationId } = require("../lib/correlationContext");
 //
 // State machine for `treasury_transfers_queue.status`:
 //   pending
@@ -245,39 +248,51 @@ const DEFAULT_CRON_EXPRESSION = "*/10 * * * *";
  * @param {number}   [options.batchSize]     Forwarded to processTreasuryQueue.
  */
 async function runTreasuryForwarderOnce(options = {}) {
-  // Lazy requires so this module stays cheap to import (mirrors the
-  // pattern in harjoot/client/index.js).
-  const models = options.models || require("../models");
-  const harjootClient = options.harjootClient
-    || require("../harjoot/client").createHarjootClient();
-  const selectStrategy = options.selectStrategy
-    || require("../harjoot/strategies/factory").selectStrategy;
+  // Mint a fresh correlation ID for this tick. Every downstream Harjoot
+  // call inherits it via AsyncLocalStorage so log lines from one cron
+  // run cluster together regardless of how many endpoints they touch.
+  const correlationId = options.correlationId || `cron-${crypto.randomUUID()}`;
 
-  let strategy;
-  let mode;
-  try {
-    ({ strategy, mode } = selectStrategy());
-  } catch (err) {
-    console.error(`${LOG_PREFIX} strategy selection failed: ${err.message || err}`);
-    return { processed: 0, mode: null, failed: true, error: err.message || String(err) };
-  }
+  return runWithCorrelationId(correlationId, async () => {
+    // Lazy requires so this module stays cheap to import (mirrors the
+    // pattern in harjoot/client/index.js).
+    const models = options.models || require("../models");
+    const harjootClient = options.harjootClient
+      || require("../harjoot/client").createHarjootClient();
+    const selectStrategy = options.selectStrategy
+      || require("../harjoot/strategies/factory").selectStrategy;
 
-  console.log(`${LOG_PREFIX} tick mode=${mode}`);
-  try {
-    return await processTreasuryQueue({
-      models,
-      strategy,
-      harjootClient,
-      usdtTransfer: options.usdtTransfer,
-      harjootWallet: options.harjootWallet,
-      batchSize: options.batchSize,
-    });
-  } catch (err) {
-    // processTreasuryQueue throws only on programmer-error dep issues.
-    // Surface the error in logs but never let it crash the cron.
-    console.error(`${LOG_PREFIX} tick aborted: ${err.message || err}`);
-    return { processed: 0, mode, failed: true, error: err.message || String(err) };
-  }
+    let strategy;
+    let mode;
+    try {
+      ({ strategy, mode } = selectStrategy());
+    } catch (err) {
+      console.error(
+        `${LOG_PREFIX} strategy selection failed correlation_id=${correlationId}: ${err.message || err}`,
+      );
+      return { processed: 0, mode: null, failed: true, error: err.message || String(err), correlationId };
+    }
+
+    console.log(`${LOG_PREFIX} tick mode=${mode} correlation_id=${correlationId}`);
+    try {
+      const result = await processTreasuryQueue({
+        models,
+        strategy,
+        harjootClient,
+        usdtTransfer: options.usdtTransfer,
+        harjootWallet: options.harjootWallet,
+        batchSize: options.batchSize,
+      });
+      return { ...result, correlationId };
+    } catch (err) {
+      // processTreasuryQueue throws only on programmer-error dep issues.
+      // Surface the error in logs but never let it crash the cron.
+      console.error(
+        `${LOG_PREFIX} tick aborted correlation_id=${correlationId}: ${err.message || err}`,
+      );
+      return { processed: 0, mode, failed: true, error: err.message || String(err), correlationId };
+    }
+  });
 }
 
 /**

--- a/backend/workers/treasuryForwarder.js
+++ b/backend/workers/treasuryForwarder.js
@@ -208,20 +208,121 @@ async function processTreasuryQueue(params) {
 }
 
 // ---------------------------------------------------------------------------
-// Scheduler — wired in Phase 8c
+// Scheduler — two-tier design.
 // ---------------------------------------------------------------------------
+//
+// runTreasuryForwarderOnce(options)
+//   Pure one-shot invocation. Builds the deps that processTreasuryQueue
+//   needs (selecting the conversion strategy by env), invokes it, and
+//   logs the outcome. ALWAYS swallows errors — a single bad tick must
+//   never crash the cron loop.
+//
+// scheduleTreasuryForwarder(options)
+//   Thin wrapper around node-cron + an in-process lock. The lock
+//   prevents a slow tick from overlapping with the next scheduled run
+//   on the SAME process. Multi-instance contention (two boxes both
+//   draining the same queue) is a separate concern handled by the
+//   row-level state machine — the worst case is a no-op fetch on the
+//   loser.
+//
+// Both export the same signature for ops convenience: a manual
+// `runTreasuryForwarderOnce()` call from a /admin route or REPL will
+// drain the queue immediately.
 
-const NOT_IMPLEMENTED =
-  "scheduleTreasuryForwarder is wired in Phase 8c; not available yet";
+const DEFAULT_CRON_EXPRESSION = "*/10 * * * *";
 
-function scheduleTreasuryForwarder(_options = {}) {
-  // TODO(Phase 8c): cron.schedule("*/10 * * * *", processTreasuryQueue) with
-  // injected deps. Single-instance lock so multiple boxes don't race.
-  throw new Error(NOT_IMPLEMENTED);
+/**
+ * Build the deps and invoke processTreasuryQueue once. Returns the
+ * worker result (or an error envelope when the dep build itself
+ * throws — e.g. the strategy factory rejects an unknown mode).
+ *
+ * @param {object} [options]
+ * @param {object} [options.models]          Defaults to require("../models").
+ * @param {object} [options.harjootClient]   Defaults to createHarjootClient().
+ * @param {function} [options.selectStrategy] Defaults to strategy factory.
+ * @param {function} [options.usdtTransfer]  Forwarded to processTreasuryQueue.
+ * @param {string}   [options.harjootWallet] Forwarded to processTreasuryQueue.
+ * @param {number}   [options.batchSize]     Forwarded to processTreasuryQueue.
+ */
+async function runTreasuryForwarderOnce(options = {}) {
+  // Lazy requires so this module stays cheap to import (mirrors the
+  // pattern in harjoot/client/index.js).
+  const models = options.models || require("../models");
+  const harjootClient = options.harjootClient
+    || require("../harjoot/client").createHarjootClient();
+  const selectStrategy = options.selectStrategy
+    || require("../harjoot/strategies/factory").selectStrategy;
+
+  let strategy;
+  let mode;
+  try {
+    ({ strategy, mode } = selectStrategy());
+  } catch (err) {
+    console.error(`${LOG_PREFIX} strategy selection failed: ${err.message || err}`);
+    return { processed: 0, mode: null, failed: true, error: err.message || String(err) };
+  }
+
+  console.log(`${LOG_PREFIX} tick mode=${mode}`);
+  try {
+    return await processTreasuryQueue({
+      models,
+      strategy,
+      harjootClient,
+      usdtTransfer: options.usdtTransfer,
+      harjootWallet: options.harjootWallet,
+      batchSize: options.batchSize,
+    });
+  } catch (err) {
+    // processTreasuryQueue throws only on programmer-error dep issues.
+    // Surface the error in logs but never let it crash the cron.
+    console.error(`${LOG_PREFIX} tick aborted: ${err.message || err}`);
+    return { processed: 0, mode, failed: true, error: err.message || String(err) };
+  }
+}
+
+/**
+ * Schedule the treasury worker on a cron. Returns the cron task so
+ * callers (tests, graceful shutdown) can stop it.
+ *
+ * @param {object} [options] All keys forwarded to runTreasuryForwarderOnce.
+ * @param {string} [options.cronExpression] Defaults to "*\/10 * * * *".
+ * @param {object} [options.cron]           Override node-cron (tests only).
+ *
+ * @returns {{ stop: Function } | null}     null when CHAIN/Harjoot are
+ *                                          disabled and the worker would
+ *                                          have nothing to do.
+ */
+function scheduleTreasuryForwarder(options = {}) {
+  const cron = options.cron || require("node-cron");
+  const cronExpression = options.cronExpression || DEFAULT_CRON_EXPRESSION;
+
+  // Multi-tick re-entrancy guard. If a tick takes longer than the cron
+  // interval (large queue, slow RPC), we skip the overlapping tick
+  // rather than queue up and stampede the chain.
+  let running = false;
+
+  const tick = async () => {
+    if (running) {
+      console.log(`${LOG_PREFIX} previous tick still running; skipping`);
+      return;
+    }
+    running = true;
+    try {
+      await runTreasuryForwarderOnce(options);
+    } finally {
+      running = false;
+    }
+  };
+
+  const task = cron.schedule(cronExpression, tick);
+  console.log(`${LOG_PREFIX} scheduled cron="${cronExpression}"`);
+  return task;
 }
 
 module.exports = {
   processTreasuryQueue,
+  runTreasuryForwarderOnce,
   scheduleTreasuryForwarder,
   __DEFAULT_BATCH_SIZE: DEFAULT_BATCH_SIZE,
+  __DEFAULT_CRON_EXPRESSION: DEFAULT_CRON_EXPRESSION,
 };

--- a/backend/workers/treasuryForwarder.js
+++ b/backend/workers/treasuryForwarder.js
@@ -9,6 +9,7 @@
 
 const crypto = require("crypto");
 const { runWithCorrelationId } = require("../lib/correlationContext");
+const { withPgAdvisoryLock, LOCK_KEYS } = require("../lib/dbLock");
 //
 // State machine for `treasury_transfers_queue.status`:
 //   pending
@@ -316,6 +317,19 @@ function scheduleTreasuryForwarder(options = {}) {
   // rather than queue up and stampede the chain.
   let running = false;
 
+  // SECURITY: in addition to the in-process flag above, a Postgres
+  // advisory lock prevents TWO INSTANCES of this process running on
+  // separate boxes from both fetching the same pending rows. Critical
+  // for non-manual conversion modes where the worker actually sends
+  // USDT — without the lock, two boxes would both transfer for the
+  // same batch. Manual mode is idempotent so it's fine either way,
+  // but we wrap unconditionally so flipping the mode is safe.
+  const getSequelize = () => {
+    if (options.sequelize) return options.sequelize;
+    const models = options.models || require("../models");
+    return models.sequelize;
+  };
+
   const tick = async () => {
     if (running) {
       console.log(`${LOG_PREFIX} previous tick still running; skipping`);
@@ -323,7 +337,17 @@ function scheduleTreasuryForwarder(options = {}) {
     }
     running = true;
     try {
-      await runTreasuryForwarderOnce(options);
+      const sequelize = getSequelize();
+      await withPgAdvisoryLock(
+        sequelize,
+        LOCK_KEYS.TREASURY_FORWARDER,
+        () => runTreasuryForwarderOnce(options),
+        {
+          onSkip: () => console.log(
+            `${LOG_PREFIX} another instance holds the lock; skipping this tick`,
+          ),
+        },
+      );
     } finally {
       running = false;
     }


### PR DESCRIPTION
This pull request implements a robust health check for the Harjoot partner API at server startup, ensuring the backend can start even if Harjoot is temporarily unavailable. It introduces a module-scoped cache for partner info, detailed error handling, and comprehensive unit tests. Additionally, it improves configuration handling for mock mode, reducing friction during development and testing.

**Harjoot partner health check and caching:**

* Adds a new `checkPartnerHealth` use case (`backend/harjoot/usecases/checkPartnerHealth.js`) that validates the Harjoot partner API key at startup, caches the partner info in memory, and ensures that failures do not block server startup. The cache retains the last-known-good value, and all errors are logged without throwing. [[1]](diffhunk://#diff-6d90f752438a7611abc20ddda03988c106c139de56f6cc1fd61045a865b64cc9R1-R88) [[2]](diffhunk://#diff-047b686339d9ac44f4e510a0d1807efdf663d34af0bb7b89f34dba564f97a74eL171-R178)
* Exposes helper functions to retrieve cached partner info and health state, and includes a test-only reset function.

**Testing:**

* Introduces comprehensive unit tests for the partner health check, covering success, failure, cache behavior, and error recording, using the mock client for full control.

**Configuration improvements:**

* Refactors `backend/harjoot/config.js` to prioritize and simplify mock mode handling. When mock mode is enabled, required credential checks are skipped, streamlining development and test workflows. [[1]](diffhunk://#diff-1abe1d22ff5e9f1550820b78ad0461a18868a62602565b367a0856aab5061411L16-R42) [[2]](diffhunk://#diff-1abe1d22ff5e9f1550820b78ad0461a18868a62602565b367a0856aab5061411L68-R86)

**Startup integration:**

* Integrates the health check into the main server startup (`backend/index.js`), replacing the previous placeholder logic with a call to the new use case and ensuring server startup resilience.