### PR TITLE
feat(backend): add issuer share counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ cd backend
 npm run migrate:issuer-profile        # adds bio, photo_url, knowledge_areas to issuers
 npm run migrate:harjoot-phase1        # adds payment, treasury, talent-invitation tables + user columns
 npm run migrate:referrals-phase1      # adds referrals, incentives_pool_ledger tables + referral_code column
+npm run migrate:issuer-share-count    # adds share_count column to issuers
 ```
 
 Each script is idempotent — safe to run more than once.

--- a/backend/documentacionAPI.md
+++ b/backend/documentacionAPI.md
@@ -677,19 +677,24 @@ Valida que el estudiante y el emisor (profesor) existen en la base de datos ante
 
 ### GET `/api/issuers/:wallet_address`
 
-Obtiene el detalle completo de un emisor por su wallet address, incluyendo su usuario y los certificados emitidos.
+Obtiene el perfil público de un emisor por su wallet address. No expone email ni otros datos
+personales. Los certificados se resumen como conteo (`certificates_issued`) y número de talentos
+distintos formados (`talents_formed`); este endpoint no devuelve la lista de certificados.
 
 **Parámetros de ruta**
 
 | Parámetro | Tipo | Descripción |
 |---|---|---|
-| `wallet_address` | `string` | Wallet address del emisor |
+| `wallet_address` | `string` | Wallet address del emisor (0x…, 42 caracteres) |
+
+**Autenticación**: No requerida.
 
 **Respuestas**
 
 | Código | Descripción |
 |---|---|
-| `200` | Detalle del emisor con usuario y certificados |
+| `200` | Perfil público del emisor |
+| `400` | Wallet address inválida |
 | `404` | Emisor no encontrado |
 | `500` | Error al obtener el emisor |
 
@@ -698,28 +703,19 @@ Obtiene el detalle completo de un emisor por su wallet address, incluyendo su us
 ```json
 {
   "issuer": {
-    "id": 1,
     "wallet_address": "0x...",
     "organization_name": "Universidad HackChain",
-    "user": {
-      "id": 3,
-      "name": "Ana",
-      "lastname": "López",
-      "email": "ana@hackchain.io",
-      "is_active": true,
-      "created_at": "2025-01-10T08:00:00.000Z"
-    },
-    "certificates": [
-      {
-        "id": 7,
-        "title": "Blockchain Basics",
-        "description": "Certificado Tokenizado HackChain",
-        "issue_date": "2025-01-15",
-        "is_revoked": false,
-        "created_at": "2025-01-15T10:00:00.000Z"
-      }
-    ],
-    "created_at": "2025-01-10T08:00:00.000Z"
+    "name": "Ana",
+    "lastname": "López",
+    "photo_url": "ipfs://<cid>",
+    "bio": "Educadora de blockchain",
+    "knowledge_areas": ["Blockchain", "Ciberseguridad"],
+    "certificates_issued": 2,
+    "share_count": 5,
+    "talents_formed": 2,
+    "joined_at": "2025-01-10T08:00:00.000Z",
+    "is_approved": true,
+    "class_settings": null
   }
 }
 ```
@@ -860,10 +856,45 @@ Retorna el total de certificados emitidos por un emisor.
 
 ---
 
+### POST `/api/issuers/:wallet/share`
+
+Incrementa en 1 el contador de veces que se ha compartido el perfil de un emisor. Endpoint
+público — cualquier visitante que comparta un perfil suma al contador. No hay seguimiento por
+usuario (MVP). Limitado a 60 solicitudes por minuto por IP.
+
+**Parámetros de ruta**
+
+| Parámetro | Tipo | Descripción |
+|---|---|---|
+| `wallet` | `string` | Wallet address del emisor (0x…, 42 caracteres) |
+
+**Autenticación**: No requerida.
+
+**Respuestas**
+
+| Código | Descripción |
+|---|---|
+| `200` | Contador incrementado; retorna el nuevo valor |
+| `400` | Wallet address inválida |
+| `404` | Emisor no encontrado |
+| `429` | Demasiadas solicitudes (rate limit) |
+| `500` | Error al registrar el share |
+
+**Ejemplo de respuesta exitosa**
+
+```json
+{
+  "success": true,
+  "share_count": 6
+}
+```
+
+---
+
 ### Notas generales
 
-- Las wallets son normalizadas a minúsculas (`.toLowerCase()`) en los endpoints `POST /mint`, `POST /increment-certificates` y `GET /:wallet/certificates-count` antes de consultar la base de datos.
-- El endpoint `GET /:wallet_address` incluye tanto el `User` asociado al emisor como todos sus `Certificates`.
+- Las wallets son normalizadas a minúsculas (`.toLowerCase()`) en los endpoints `POST /mint`, `POST /increment-certificates`, `GET /:wallet/certificates-count` y `POST /:wallet/share` antes de consultar la base de datos.
+- El endpoint `GET /:wallet_address` es público y devuelve solo campos públicos del emisor (sin email ni lista de certificados); los certificados se resumen en `certificates_issued` y `talents_formed`, e incluye `share_count`.
 - `POST /authorize` delega la lógica de blockchain al servicio `authorizeIssuer`.
 - `POST /mint` solo realiza validaciones previas al minteo; el minteo real ocurre en el frontend o en un servicio externo.
 - Si un emisor no tiene certificados registrados, `GET /:wallet/certificates-count` retorna `{ "total": 0 }` sin error.

--- a/backend/models/issuers.js
+++ b/backend/models/issuers.js
@@ -17,6 +17,7 @@ module.exports = (sequelize, DataTypes) => {
     },
     organization_name: { type: DataTypes.STRING(255), allowNull: false },
     certificates_issued: { type: DataTypes.INTEGER, defaultValue: 0, allowNull: false },
+    share_count: { type: DataTypes.INTEGER, defaultValue: 0, allowNull: false },
     photo_url: { type: DataTypes.STRING(500), allowNull: true },
     bio: { type: DataTypes.TEXT, allowNull: true },
     knowledge_areas: { type: DataTypes.JSONB, allowNull: true, defaultValue: [] },

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
     "dev": "nodemon index.js",
     "test": "jest --runInBand --detectOpenHandles",
     "migrate:issuer-profile": "node scripts/migrate-issuer-profile.js",
+    "migrate:issuer-share-count": "node scripts/migrate-issuer-share-count.js",
     "migrate:harjoot-phase1": "node scripts/migrate-harjoot-phase1.js",
     "migrate:referrals-phase1": "node scripts/migrate-referrals-phase1.js"
   },

--- a/backend/routes/issuers.js
+++ b/backend/routes/issuers.js
@@ -532,6 +532,7 @@ router.get("/:wallet_address", async (req, res) => {
         bio: issuer.bio || null,
         knowledge_areas: issuer.knowledge_areas || [],
         certificates_issued: issuer.certificates_issued,
+        share_count: issuer.share_count,
         talents_formed,
         joined_at: issuer.User?.created_at || issuer.created_at,
         is_approved: issuer.User?.educator_approval_status === 'approved',
@@ -656,6 +657,40 @@ router.get("/:wallet/certificates-count", async (req, res) => {
   } catch (e) {
     console.error("Error fetching certificates:", e);
     res.status(500).json({ total: 0 });
+  }
+});
+
+// 60 requests/min per IP — public endpoint, mirrors featuredLimiter.
+const shareLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  message: { error: "Too many requests, slow down" },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+// POST /api/issuers/:wallet/share — public, increments the profile share counter.
+// No auth: anyone sharing a public profile bumps the count. No per-user tracking (MVP).
+router.post("/:wallet/share", shareLimiter, async (req, res) => {
+  try {
+    const wallet = req.params.wallet.toLowerCase();
+    if (!/^0x[a-fA-F0-9]{40}$/.test(wallet)) {
+      return res.status(400).json({ error: "Invalid wallet address" });
+    }
+
+    const issuer = await Issuer.findOne({
+      where: { wallet_address: wallet },
+      attributes: ["id", "share_count"],
+    });
+    if (!issuer) return res.status(404).json({ error: "Issuer not found" });
+
+    await issuer.increment("share_count");
+    await issuer.reload();
+
+    return res.json({ success: true, share_count: issuer.share_count });
+  } catch (err) {
+    console.error("POST /api/issuers/:wallet/share error:", err);
+    return res.status(500).json({ error: "Failed to register share" });
   }
 });
 

--- a/backend/scripts/migrate-issuer-share-count.js
+++ b/backend/scripts/migrate-issuer-share-count.js
@@ -1,0 +1,35 @@
+require("dotenv").config({ path: require("path").join(__dirname, "../.env") });
+
+const { sequelize } = require("../models");
+const { DataTypes } = require("sequelize");
+
+async function run() {
+  const q = sequelize.getQueryInterface();
+  const columns = await q.describeTable("issuers");
+
+  const toAdd = [
+    {
+      name: "share_count",
+      missing: !columns.share_count,
+      // defaultValue backfills existing rows so the NOT NULL add succeeds.
+      def: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    },
+  ];
+
+  for (const col of toAdd) {
+    if (col.missing) {
+      await q.addColumn("issuers", col.name, col.def);
+      console.log(`Added column: ${col.name}`);
+    } else {
+      console.log(`Column already exists: ${col.name}`);
+    }
+  }
+
+  await sequelize.close();
+  console.log("Migration complete.");
+}
+
+run().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/backend/tests/issuers.test.js
+++ b/backend/tests/issuers.test.js
@@ -1,0 +1,147 @@
+// backend/tests/issuers.test.js
+//
+// Tests for the issuer share counter:
+//   POST /api/issuers/:wallet/share  and  share_count in GET /api/issuers/:wallet_address
+// Covers: 200 with share_count, 404 unknown wallet, 400 malformed wallet.
+
+const request = require("supertest");
+const express = require("express");
+const bodyParser = require("body-parser");
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+
+jest.setTimeout(20000);
+
+jest.mock("../services/redis", () => ({
+  cacheSession: jest.fn().mockResolvedValue(undefined),
+  deleteSession: jest.fn().mockResolvedValue(undefined),
+  sessionExists: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock("express-rate-limit", () => () => (req, res, next) => next());
+
+describe("Issuer share counter", () => {
+  let sequelize;
+  let User, Issuer, Student, Recruiter, Certificate, UserSession;
+  let app;
+
+  const makeWallet = () => "0x" + crypto.randomBytes(20).toString("hex");
+
+  const seedIssuer = async ({ wallet, status = "approved", org = "Org" } = {}) => {
+    const w = wallet ?? makeWallet();
+    await User.create({
+      wallet_address: w,
+      role: "issuer",
+      name: "Edu",
+      nonce: crypto.randomBytes(16).toString("hex"),
+      educator_approval_status: status,
+    });
+    await Issuer.create({
+      wallet_address: w,
+      organization_name: org,
+      certificates_issued: 0,
+    });
+    return w;
+  };
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", { logging: false });
+    const DataTypes = SequelizePkg.DataTypes;
+
+    User = require("../models/users")(sequelize, DataTypes);
+    Student = require("../models/students")(sequelize, DataTypes);
+    Issuer = require("../models/issuers")(sequelize, DataTypes);
+    Recruiter = require("../models/recruiters")(sequelize, DataTypes);
+    Certificate = require("../models/certificates")(sequelize, DataTypes);
+    UserSession = require("../models/userSessions")(sequelize, DataTypes);
+
+    const modelsMock = {
+      User, Student, Issuer, Recruiter, Certificate, UserSession,
+      sequelize,
+      Sequelize: SequelizePkg,
+    };
+
+    Object.values(modelsMock).forEach((m) => m?.associate?.(modelsMock));
+
+    sequelize.random = () => SequelizePkg.literal("RANDOM()");
+
+    await sequelize.sync({ force: true });
+
+    process.env.JWT_SECRET = "test-issuers-secret";
+    process.env.REFRESH_SECRET = "test-issuers-refresh";
+
+    jest.isolateModules(() => {
+      jest.doMock("../models", () => modelsMock);
+      const issuersRoute = require("../routes/issuers");
+      app = express();
+      app.use(bodyParser.json());
+      app.use("/api/issuers", issuersRoute);
+    });
+  });
+
+  afterAll(async () => {
+    jest.resetModules();
+    if (sequelize) await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /api/issuers/:wallet/share
+  // -------------------------------------------------------------------------
+
+  test("share: 200 increments share_count from 0 to 1", async () => {
+    const wallet = await seedIssuer();
+
+    const res = await request(app)
+      .post(`/api/issuers/${wallet}/share`)
+      .expect(200);
+
+    expect(res.body).toEqual({ success: true, share_count: 1 });
+  });
+
+  test("share: consecutive posts keep incrementing", async () => {
+    const wallet = await seedIssuer();
+
+    await request(app).post(`/api/issuers/${wallet}/share`).expect(200);
+    const res = await request(app)
+      .post(`/api/issuers/${wallet}/share`)
+      .expect(200);
+
+    expect(res.body.share_count).toBe(2);
+  });
+
+  test("share: 404 when the wallet does not belong to any issuer", async () => {
+    const res = await request(app)
+      .post(`/api/issuers/${makeWallet()}/share`)
+      .expect(404);
+
+    expect(res.body).toHaveProperty("error");
+  });
+
+  test("share: 400 when the wallet is malformed", async () => {
+    const res = await request(app)
+      .post("/api/issuers/not-a-wallet/share")
+      .expect(400);
+
+    expect(res.body).toHaveProperty("error");
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /api/issuers/:wallet_address — share_count is exposed
+  // -------------------------------------------------------------------------
+
+  test("profile: GET exposes share_count and reflects the current value", async () => {
+    const wallet = await seedIssuer();
+
+    const before = await request(app).get(`/api/issuers/${wallet}`).expect(200);
+    expect(before.body.issuer).toHaveProperty("share_count", 0);
+
+    await request(app).post(`/api/issuers/${wallet}/share`).expect(200);
+
+    const after = await request(app).get(`/api/issuers/${wallet}`).expect(200);
+    expect(after.body.issuer.share_count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Why
Unblocks the profile **share button** (frontend) and **social preview** (OG tags), which need a count of how many times an educator profile has been shared.

## What
- `share_count` column added to the `Issuer` model + idempotent migration (`scripts/migrate-issuer-share-count.js`, registered as `npm run migrate:issuer-share-count`).
- `share_count` exposed in `GET /api/issuers/:wallet_address`.
- New **public** `POST /api/issuers/:wallet/share` (IP rate-limited, 60/min, mirrors `/featured`) that increments the counter and returns `{ success: true, share_count: N }`. Inline, matching `/increment-certificates`.
- `documentacionAPI.md`: documented the new POST, added `share_count` to the GET, and corrected the stale `GET /:wallet_address` section (it documented `user`, `email` and a `certificates` array the code no longer returns).
- New `tests/issuers.test.js` covering 200 (with `share_count`), 404 (unknown wallet), 400 (malformed wallet).

## Impact
Additive only. New column defaults to `0`; existing responses only gain the `share_count` field. **Run `npm run migrate:issuer-share-count` on deploy** (use the direct/unpooled Neon endpoint — DDL via the pooler/PgBouncer is unreliable).

## Verification (local)
- Migration adds the column and is idempotent.
- curl: GET exposes `share_count`; POST → `1` → `2` (persisted); unknown wallet → 404; malformed → 400.
- `issuers.test.js`: 5/5 pass. Full suite: 678 pass. The 7 failing tests (register, referralModels, precheckCertificate) are **pre-existing** and unrelated to this change (confirmed on the original model).