### PR TITLE
fix(backend): use shared Redis store for issuer rate limiters

### DIFF
--- a/backend/routes/issuers.js
+++ b/backend/routes/issuers.js
@@ -2,6 +2,7 @@
 const express = require("express");
 const router = express.Router();
 const rateLimit = require("express-rate-limit");
+const buildRateLimitStore = require("../lib/rateLimitStore");
 const { Issuer, Student, User, Certificate, ClassRequest } = require("../models");
 const { authorizeIssuer } = require("../services/authorizeIssuer.js");
 const { validateDeletionMessage, deleteIssuerAccount } = require("../services/issuerService");
@@ -127,13 +128,16 @@ router.post("/me/reapply", authenticate, reapplyLimiter, async (req, res) => {
 });
 
 
-// 60 requests/min per IP — public endpoint, no auth needed
+// 60 requests/min per IP — public endpoint, no auth needed.
+// Redis-backed store so the limit is shared across instances (memory store
+// would give effective_max = max × instance_count behind a load balancer).
 const featuredLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 60,
   message: { error: "Too many requests, slow down" },
   standardHeaders: true,
   legacyHeaders: false,
+  store: buildRateLimitStore("/api/issuers/featured"),
 });
 
 // GET /api/issuers/featured — random approved educators for discovery widget
@@ -661,12 +665,14 @@ router.get("/:wallet/certificates-count", async (req, res) => {
 });
 
 // 60 requests/min per IP — public endpoint, mirrors featuredLimiter.
+// Redis-backed store so the limit is shared across instances.
 const shareLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 60,
   message: { error: "Too many requests, slow down" },
   standardHeaders: true,
   legacyHeaders: false,
+  store: buildRateLimitStore("/api/issuers/share"),
 });
 
 // POST /api/issuers/:wallet/share — public, increments the profile share counter.


### PR DESCRIPTION
## Why
`featuredLimiter` and `shareLimiter` in `routes/issuers.js` used the default **in-memory** store. Behind a load balancer each instance keeps its own counter, so the effective limit is `max × instance_count`. A security review already flagged this pattern for the other per-route limiters. Follow-up to #88 (share_count).

## What
Wire both limiters to **`buildRateLimitStore`** (`backend/lib/rateLimitStore.js`) — the same helper `auth`, `certificates` and `admin` already use:
- With `REDIS_URL` set → Redis-backed store shared across instances.
- Without it (local/CI) → falls back to the in-memory store, so tests and local dev are unaffected (fail-safe).

Scope: only `routes/issuers.js` (both public limiters), as agreed. No API or endpoint-logic change.

## Impact
No behavior change for single-instance/local. In production, the two public issuer limiters now share rate-limit state via Redis, consistent with the rest of the app.

## Verification (local)
- `npm test`: `issuers.test.js` + `educator-discovery.test.js` → **27/27 pass** (helper returns MemoryStore without `REDIS_URL`, so no regression).
- Runtime with Docker Postgres + Redis (`REDIS_URL` set): hitting `POST /api/issuers/:wallet/share` and `GET /api/issuers/featured` creates the rate-limit key in Redis (`rl:*`) and increments it → confirms the limiters now use Redis.
- Boot log without Redis shows the expected `[rateLimitStore] REDIS_URL not set … falls back to in-memory` for both limiters → confirms fail-safe.