### PR TITLE
feat(frontend): add educator profile share button with QR and social …

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -59,6 +59,7 @@ VITE_API_URL=http://localhost:3001          # Backend base URL
 VITE_REOWN_PROJECT_ID=...                   # Reown AppKit project ID (wallet connection)
 VITE_CONTRACT_ADDRESS=0x...                 # HackCertificate contract address on Polygon
 VITE_CHAIN_ID=137                           # 137 = Polygon mainnet, 80002 = Polygon Amoy testnet
+VITE_QR_API_URL=...                         # Base URL of the QR code provider used to generate profile QR codes
 ```
 
 ## Available Scripts

--- a/frontend/src/components/ShareProfileButton.tsx
+++ b/frontend/src/components/ShareProfileButton.tsx
@@ -4,7 +4,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { P } from '@/components/profile/palette';
 import { useShareProfile } from '@/hooks/useShareProfile';
 import { CopyButton } from '@/components/CopyButton';
-import {useTranslation} from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import {
   FaLinkedin,
   FaWhatsapp,
@@ -14,12 +14,12 @@ import { FaXTwitter } from 'react-icons/fa6';
 interface ShareProfileButtonProps {
   profileUrl: string;
   displayName: string;
-  issuerId: string;
+  issuerWallet: string;
 }
 
 
-export function ShareProfileButton({ profileUrl, displayName, issuerId }: ShareProfileButtonProps) {
-  const share = useShareProfile(profileUrl, displayName, issuerId);
+export function ShareProfileButton({ profileUrl, displayName, issuerWallet }: ShareProfileButtonProps) {
+  const share = useShareProfile(profileUrl, displayName, issuerWallet);
   
   const shareActions = [
     { key: 'whatsapp', label: 'WhatsApp', icon: <FaWhatsapp className="w-6 h-6 text-green-500" />, href: share.shareLinks.whatsapp },
@@ -48,15 +48,15 @@ export function ShareProfileButton({ profileUrl, displayName, issuerId }: ShareP
       >
         <DialogHeader className="px-6 pt-6 pb-3">
           <DialogTitle className="text-left text-xl font-semibold tracking-tight text-white" style={{ color: P.textPrimary }}>
-            Share profile
+            {t('shareProfile.title')}
           </DialogTitle>
         </DialogHeader>
 
         <div className="px-6 pb-6 space-y-4 min-w-0">
-          <CopyLinkCard profileUrl={profileUrl} onLinkCopy={share.handleLinkCopy} />
+          <CopyLinkCard profileUrl={profileUrl} onLinkCopy={share.handleLinkCopy} t={t} />
           <div>
             <label className="font-body text-[10px] uppercase tracking-[0.22em] text-white/40 font-bold mb-2 block">
-              Share via
+              {t('shareProfile.shareVia')}
             </label>
             <div className="flex justify-center gap-6 mt-8">
               {shareActions.map((action) => (
@@ -81,12 +81,13 @@ export function ShareProfileButton({ profileUrl, displayName, issuerId }: ShareP
             </div>
           </div>
  
-          <SectionDivider label="Share via" />
+         
 
           <QrCodeCard
             qrUrl={share.qrUrl}
             qrStatus={share.qrStatus}
             displayName={displayName}
+            t={t}
             onLoad={share.handleQrLoad}
             onError={share.handleQrError}
             onRetry={share.retryQr}
@@ -115,14 +116,15 @@ function SectionDivider({ label }: SectionDividerProps) {
 interface CopyLinkCardProps {
   profileUrl: string;
   onLinkCopy: () => void;
+  t: (key: string) => string;
 }
 
 
-function CopyLinkCard({ profileUrl, onLinkCopy }: CopyLinkCardProps) {
+function CopyLinkCard({ profileUrl, onLinkCopy, t }: CopyLinkCardProps) {
   return (
     <div>
       <label className="font-body text-[10px] uppercase tracking-[0.22em] text-white/40 font-bold mb-2 block">
-        Profile Link
+        {t('shareProfile.profileLink')}
       </label>
       <div className="flex items-center gap-3 bg-black/40 rounded-2xl p-3 pl-5 border border-white/5">
         <span className="truncate text-sm sm:text-base text-slate-300 font-mono flex-1 min-w-0">{profileUrl}</span>
@@ -140,21 +142,22 @@ interface QrCodeCardProps {
   qrUrl: string;
   qrStatus: 'loading' | 'success' | 'error';
   displayName: string;
+  t: (key: string) => string;
   onLoad: () => void;
   onError: () => void;
   onRetry: () => void;
 }
 
- function QrCodeCard({ qrUrl, qrStatus, displayName, onLoad, onError, onRetry }: QrCodeCardProps) {
+ function QrCodeCard({ qrUrl, qrStatus, displayName, t, onLoad, onError, onRetry }: QrCodeCardProps) {
   return (
     <div className="bg-black/40 rounded-2xl border border-white/5 p-4 text-center">
       <label className="font-body text-[10px] uppercase tracking-[0.22em] text-white/40 font-bold mb-3 block">
-        QR code
+        {t('shareProfile.qrCode')}
       </label>
-      <QrCodeFrame qrUrl={qrUrl} qrStatus={qrStatus} displayName={displayName} onLoad={onLoad} onError={onError} onRetry={onRetry} />
+      <QrCodeFrame qrUrl={qrUrl} qrStatus={qrStatus} displayName={displayName} t ={t} onLoad={onLoad} onError={onError} onRetry={onRetry} />
       {qrStatus === 'success' && (
         <>
-          <p className="font-body text-[10px] uppercase tracking-[0.22em] text-white/40 font-bold mb-3 block">Scan to view profile {displayName}</p>
+          <p className="font-body text-[10px] uppercase tracking-[0.22em] text-white/40 font-bold mb-3 block"> {t('shareProfile.scanProfile')} {displayName}</p>
         </>
       )
     }
@@ -162,21 +165,21 @@ interface QrCodeCardProps {
   );
 }
 
-function QrCodeFrame({ qrUrl, qrStatus, displayName, onLoad, onError, onRetry }: QrCodeCardProps) {
+function QrCodeFrame({ qrUrl, qrStatus, displayName, t, onLoad, onError, onRetry }: QrCodeCardProps) {
   return (
     <div className="mx-auto mb-4 flex h-36 w-36 items-center justify-center overflow-hidden rounded-xl bg-white">
       {qrStatus === 'loading' && <div className="h-full w-full animate-pulse bg-slate-200" />}
 
       {qrStatus === 'error' && (
         <div className="flex h-full w-full flex-col items-center justify-center gap-2 text-xs text-slate-500">
-          <span>Couldn't load QR</span>
+          <span>{t('shareProfile.couldNotLoadQrCode')}</span>
           <button
             type="button"
             onClick={onRetry}
             className="flex items-center gap-1 rounded-lg bg-slate-100 px-2 py-1 transition-colors hover:bg-slate-200"
           >
             <RefreshCw className="h-3 w-3" />
-            Retry
+            {t('shareProfile.retry')}
           </button>
         </div>
       )}

--- a/frontend/src/components/ShareProfileButton.tsx
+++ b/frontend/src/components/ShareProfileButton.tsx
@@ -45,6 +45,7 @@ export function ShareProfileButton({ profileUrl, displayName, issuerWallet }: Sh
       </DialogTrigger>
       <DialogContent className="sm:max-w-lg rounded-2xl border-0 p-0 overflow-hidden"
        style={{ background: 'radial-gradient(at 80% 0%, oklch(0.7 0.16 280 / 0.18) 0%, transparent 55%), #09090b' }}
+       aria-describedby={undefined}
       >
         <DialogHeader className="px-6 pt-6 pb-3">
           <DialogTitle className="text-left text-xl font-semibold tracking-tight text-white" style={{ color: P.textPrimary }}>
@@ -95,20 +96,6 @@ export function ShareProfileButton({ profileUrl, displayName, issuerWallet }: Sh
         </div>
       </DialogContent>
     </Dialog>
-  );
-}
-
-interface SectionDividerProps {
-  label: string;
-}
-
-function SectionDivider({ label }: SectionDividerProps) {
-  return (
-    <div className="flex items-center gap-3">
-      <span className="h-px flex-1 bg-white/5" />
-      <span className="font-body text-[10px] uppercase tracking-[0.22em] text-white/40 font-bold">{label}</span>
-      <span className="h-px flex-1 bg-white/5" />
-    </div>
   );
 }
 
@@ -172,7 +159,7 @@ function QrCodeFrame({ qrUrl, qrStatus, displayName, t, onLoad, onError, onRetry
 
       {qrStatus === 'error' && (
         <div className="flex h-full w-full flex-col items-center justify-center gap-2 text-xs text-slate-500">
-          <span>{t('shareProfile.couldNotLoadQrCode')}</span>
+          <span>{t('shareProfile.couldNotLoadQr')}</span>
           <button
             type="button"
             onClick={onRetry}

--- a/frontend/src/components/ShareProfileButton.tsx
+++ b/frontend/src/components/ShareProfileButton.tsx
@@ -1,0 +1,193 @@
+import { Check, Copy, Linkedin, MessageCircleMore, RefreshCw, Share2, Twitter } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { P } from '@/components/profile/palette';
+import { useShareProfile } from '@/hooks/useShareProfile';
+import { CopyButton } from '@/components/CopyButton';
+import {useTranslation} from 'react-i18next'
+import {
+  FaLinkedin,
+  FaWhatsapp,
+} from 'react-icons/fa';
+import { FaXTwitter } from 'react-icons/fa6';
+
+interface ShareProfileButtonProps {
+  profileUrl: string;
+  displayName: string;
+  issuerId: string;
+}
+
+
+export function ShareProfileButton({ profileUrl, displayName, issuerId }: ShareProfileButtonProps) {
+  const share = useShareProfile(profileUrl, displayName, issuerId);
+  
+  const shareActions = [
+    { key: 'whatsapp', label: 'WhatsApp', icon: <FaWhatsapp className="w-6 h-6 text-green-500" />, href: share.shareLinks.whatsapp },
+    { key: 'linkedin', label: 'LinkedIn', icon: <FaLinkedin className="w-6 h-6 text-[#0A66C2]" />, href: share.shareLinks.linkedin },
+    { key: 'twitter', label: 'Twitter / X', icon: <FaXTwitter className="w-6 h-6 text-white" />, href: share.shareLinks.twitter },
+  ];
+  
+  const { t } = useTranslation();
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          className="inline-flex h-[34px] min-h-[34px] items-center justify-center gap-1.5 rounded-md px-3 text-[11px] font-mono tracking-wide whitespace-nowrap cursor-pointer select-none"
+          style={{ borderColor: P.border, color: P.textSecondary, backgroundColor: P.surface }}
+          aria-label="Share profile"
+        >
+          <Share2 className="h-3 w-3 text-purple-800" />
+          {t('Share')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-lg rounded-2xl border-0 p-0 overflow-hidden"
+       style={{ background: 'radial-gradient(at 80% 0%, oklch(0.7 0.16 280 / 0.18) 0%, transparent 55%), #09090b' }}
+      >
+        <DialogHeader className="px-6 pt-6 pb-3">
+          <DialogTitle className="text-left text-xl font-semibold tracking-tight text-white" style={{ color: P.textPrimary }}>
+            Share profile
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="px-6 pb-6 space-y-4 min-w-0">
+          <CopyLinkCard profileUrl={profileUrl} onLinkCopy={share.handleLinkCopy} />
+          <div>
+            <label className="font-body text-[10px] uppercase tracking-[0.22em] text-white/40 font-bold mb-2 block">
+              Share via
+            </label>
+            <div className="flex justify-center gap-6 mt-8">
+              {shareActions.map((action) => (
+                <a
+                  key={action.key}
+                  href={action.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={share.handleSocialClick}
+                  aria-label={action.label}
+                  className="
+                  inline-flex items-center justify-center
+                  w-11 h-11 rounded-full
+                  bg-white/10
+                  transition-all duration-300
+                  hover:bg-white/20 hover:scale-110
+                  "
+                >
+                  {action.icon}
+                </a>
+              ))}
+            </div>
+          </div>
+ 
+          <SectionDivider label="Share via" />
+
+          <QrCodeCard
+            qrUrl={share.qrUrl}
+            qrStatus={share.qrStatus}
+            displayName={displayName}
+            onLoad={share.handleQrLoad}
+            onError={share.handleQrError}
+            onRetry={share.retryQr}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+interface SectionDividerProps {
+  label: string;
+}
+
+function SectionDivider({ label }: SectionDividerProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="h-px flex-1 bg-white/5" />
+      <span className="font-body text-[10px] uppercase tracking-[0.22em] text-white/40 font-bold">{label}</span>
+      <span className="h-px flex-1 bg-white/5" />
+    </div>
+  );
+}
+
+
+interface CopyLinkCardProps {
+  profileUrl: string;
+  onLinkCopy: () => void;
+}
+
+
+function CopyLinkCard({ profileUrl, onLinkCopy }: CopyLinkCardProps) {
+  return (
+    <div>
+      <label className="font-body text-[10px] uppercase tracking-[0.22em] text-white/40 font-bold mb-2 block">
+        Profile Link
+      </label>
+      <div className="flex items-center gap-3 bg-black/40 rounded-2xl p-3 pl-5 border border-white/5">
+        <span className="truncate text-sm sm:text-base text-slate-300 font-mono flex-1 min-w-0">{profileUrl}</span>
+        {/* onLinkCopy rides the native click bubble from CopyButton without modifying that shared component */}
+        <div onClick={onLinkCopy} className="contents">
+          <CopyButton value={profileUrl} className="bg-white/5 hover:bg-white/10 text-white rounded-xl" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+interface QrCodeCardProps {
+  qrUrl: string;
+  qrStatus: 'loading' | 'success' | 'error';
+  displayName: string;
+  onLoad: () => void;
+  onError: () => void;
+  onRetry: () => void;
+}
+
+ function QrCodeCard({ qrUrl, qrStatus, displayName, onLoad, onError, onRetry }: QrCodeCardProps) {
+  return (
+    <div className="bg-black/40 rounded-2xl border border-white/5 p-4 text-center">
+      <label className="font-body text-[10px] uppercase tracking-[0.22em] text-white/40 font-bold mb-3 block">
+        QR code
+      </label>
+      <QrCodeFrame qrUrl={qrUrl} qrStatus={qrStatus} displayName={displayName} onLoad={onLoad} onError={onError} onRetry={onRetry} />
+      {qrStatus === 'success' && (
+        <>
+          <p className="font-body text-[10px] uppercase tracking-[0.22em] text-white/40 font-bold mb-3 block">Scan to view profile {displayName}</p>
+        </>
+      )
+    }
+    </div>
+  );
+}
+
+function QrCodeFrame({ qrUrl, qrStatus, displayName, onLoad, onError, onRetry }: QrCodeCardProps) {
+  return (
+    <div className="mx-auto mb-4 flex h-36 w-36 items-center justify-center overflow-hidden rounded-xl bg-white">
+      {qrStatus === 'loading' && <div className="h-full w-full animate-pulse bg-slate-200" />}
+
+      {qrStatus === 'error' && (
+        <div className="flex h-full w-full flex-col items-center justify-center gap-2 text-xs text-slate-500">
+          <span>Couldn't load QR</span>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="flex items-center gap-1 rounded-lg bg-slate-100 px-2 py-1 transition-colors hover:bg-slate-200"
+          >
+            <RefreshCw className="h-3 w-3" />
+            Retry
+          </button>
+        </div>
+      )}
+
+      <img
+        src={qrUrl}
+        alt={`QR code for ${displayName}`}
+        onLoad={onLoad}
+        onError={onError}
+        className={qrStatus === 'success' ? 'h-full w-full object-contain p-2' : 'hidden'}
+      />
+    </div>
+  );
+}

--- a/frontend/src/hooks/useShareProfile.ts
+++ b/frontend/src/hooks/useShareProfile.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { api } from '@/services/api';
-const QR_API_URL = import.meta.env.VITE_QR_API_URL;
+const QR_API_URL = import.meta.env.VITE_QR_API_URL || 'https://api.qrserver.com/v1/create-qr-code/';
 
 type QrStatus = 'loading' | 'success' | 'error';
 type SharePlatform = 'whatsapp' | 'linkedin' | 'twitter';

--- a/frontend/src/hooks/useShareProfile.ts
+++ b/frontend/src/hooks/useShareProfile.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { api } from '@/services/api';
+const QR_API_URL = import.meta.env.VITE_QR_API_URL;
 
 type QrStatus = 'loading' | 'success' | 'error';
 type SharePlatform = 'whatsapp' | 'linkedin' | 'twitter';
@@ -21,7 +22,7 @@ interface UseShareProfileResult {
   retryQr: () => void;
 }
 
-function buildShareUrl(platform: SharePlatform, url: string, name: string): string {
+ export function buildShareUrl(platform: SharePlatform, url: string, name: string): string {
   const text = `Check out ${name}'s profile on HackChain`;
 
   switch (platform) {
@@ -34,7 +35,7 @@ function buildShareUrl(platform: SharePlatform, url: string, name: string): stri
   }
 }
 
-function buildShareLinks(profileUrl: string, displayName: string): ShareLinks {
+export function buildShareLinks(profileUrl: string, displayName: string): ShareLinks {
   return {
     whatsapp: buildShareUrl('whatsapp', profileUrl, displayName),
     linkedin: buildShareUrl('linkedin', profileUrl, displayName),
@@ -43,24 +44,24 @@ function buildShareLinks(profileUrl: string, displayName: string): ShareLinks {
 }
 
 // cacheBuster forces the <img> to re-request the QR after a manual retry
-function createQrDataUrl(value: string, cacheBuster: number): string {
+export function createQrDataUrl(value: string, cacheBuster: number): string {
   const encoded = encodeURIComponent(value);
-  return `https://api.qrserver.com/v1/create-qr-code/?size=180x180&data=${encoded}&t=${cacheBuster}`;
+  return `${QR_API_URL}?size=180x180&data=${encoded}&t=${cacheBuster}`;
 }
 
-export function useShareProfile(profileUrl: string, displayName: string, issuerId: string): UseShareProfileResult {
+export function useShareProfile(profileUrl: string, displayName: string, issuerWallet: string): UseShareProfileResult {
   const [qrStatus, setQrStatus] = useState<QrStatus>('loading');
   const [qrRetryCount, setQrRetryCount] = useState(0);
 
   const qrUrl = useMemo(() => createQrDataUrl(profileUrl, qrRetryCount), [profileUrl, qrRetryCount]);
 
   const handleLinkCopy = useCallback(() => {
-    api.registerProfileShare(issuerId);
-  }, [issuerId]);
+    api.registerProfileShare(issuerWallet);
+  }, [issuerWallet]);
 
   const handleSocialClick = useCallback(() => {
-    api.registerProfileShare(issuerId);
-  }, [issuerId]);
+    api.registerProfileShare(issuerWallet);
+  }, [issuerWallet]);
 
   const handleQrLoad = useCallback(() => setQrStatus('success'), []);
   const handleQrError = useCallback(() => setQrStatus('error'), []);

--- a/frontend/src/hooks/useShareProfile.ts
+++ b/frontend/src/hooks/useShareProfile.ts
@@ -1,0 +1,76 @@
+import { useCallback, useMemo, useState } from 'react';
+import { api } from '@/services/api';
+
+type QrStatus = 'loading' | 'success' | 'error';
+type SharePlatform = 'whatsapp' | 'linkedin' | 'twitter';
+
+interface ShareLinks {
+  whatsapp: string;
+  linkedin: string;
+  twitter: string;
+}
+
+interface UseShareProfileResult {
+  qrUrl: string;
+  qrStatus: QrStatus;
+  shareLinks: ShareLinks;
+  handleLinkCopy: () => void;
+  handleSocialClick: () => void;
+  handleQrLoad: () => void;
+  handleQrError: () => void;
+  retryQr: () => void;
+}
+
+function buildShareUrl(platform: SharePlatform, url: string, name: string): string {
+  const text = `Check out ${name}'s profile on HackChain`;
+
+  switch (platform) {
+    case 'whatsapp':
+      return `https://wa.me/?text=${encodeURIComponent(`${text} ${url}`)}`;
+    case 'linkedin':
+      return `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`;
+    case 'twitter':
+      return `https://twitter.com/intent/tweet?text=${encodeURIComponent(`${text} ${url}`)}`;
+  }
+}
+
+function buildShareLinks(profileUrl: string, displayName: string): ShareLinks {
+  return {
+    whatsapp: buildShareUrl('whatsapp', profileUrl, displayName),
+    linkedin: buildShareUrl('linkedin', profileUrl, displayName),
+    twitter: buildShareUrl('twitter', profileUrl, displayName),
+  };
+}
+
+// cacheBuster forces the <img> to re-request the QR after a manual retry
+function createQrDataUrl(value: string, cacheBuster: number): string {
+  const encoded = encodeURIComponent(value);
+  return `https://api.qrserver.com/v1/create-qr-code/?size=180x180&data=${encoded}&t=${cacheBuster}`;
+}
+
+export function useShareProfile(profileUrl: string, displayName: string, issuerId: string): UseShareProfileResult {
+  const [qrStatus, setQrStatus] = useState<QrStatus>('loading');
+  const [qrRetryCount, setQrRetryCount] = useState(0);
+
+  const qrUrl = useMemo(() => createQrDataUrl(profileUrl, qrRetryCount), [profileUrl, qrRetryCount]);
+
+  const handleLinkCopy = useCallback(() => {
+    api.registerProfileShare(issuerId);
+  }, [issuerId]);
+
+  const handleSocialClick = useCallback(() => {
+    api.registerProfileShare(issuerId);
+  }, [issuerId]);
+
+  const handleQrLoad = useCallback(() => setQrStatus('success'), []);
+  const handleQrError = useCallback(() => setQrStatus('error'), []);
+
+  const retryQr = useCallback(() => {
+    setQrStatus('loading');
+    setQrRetryCount((count) => count + 1);
+  }, []);
+
+  const shareLinks = useMemo(() => buildShareLinks(profileUrl, displayName), [profileUrl, displayName]);
+
+  return { qrUrl, qrStatus, shareLinks, handleLinkCopy, handleSocialClick, handleQrLoad, handleQrError, retryQr };
+}

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -1023,5 +1023,14 @@
     "emptyTalent": "No classes scheduled yet. Explore educators and book your first session.",
     "emptyEducator": "No classes scheduled yet.",
     "myCalendar": "My Calendar"
+  },
+    "shareProfile": {
+    "title": "Share profile",
+    "shareVia": "Share via",
+    "profileLink": "Profile Link",
+    "qrCode": "QR code",
+    "retry": "Retry",
+    "couldNotLoadQr": "Couldn't load QR",
+    "scanProfile": "Scan to view profile"
   }
 }

--- a/frontend/src/locales/es/translation.json
+++ b/frontend/src/locales/es/translation.json
@@ -1023,5 +1023,14 @@
     "emptyTalent": "Aún no tenés clases agendadas. Explorá educadores y agenda tu primera sesión.",
     "emptyEducator": "Aún no tenés clases agendadas.",
     "myCalendar": "Mi Calendario"
+  },
+    "shareProfile": {
+    "title": "Compartir perfil",
+    "shareVia": "Compartir mediante",
+    "profileLink": "Enlace del perfil",
+    "qrCode": "Código QR",
+    "retry": "Reintentar",
+    "couldNotLoadQr": "No se pudo cargar el código QR",
+    "scanProfile": "Escanea para ver el perfil de"
   }
 }

--- a/frontend/src/pages/EducatorProfile.tsx
+++ b/frontend/src/pages/EducatorProfile.tsx
@@ -461,7 +461,7 @@ const EducatorProfile = () => {
                         />
                         {t('since')} {formatDate(educator.joined_at)}
                       </div>
-                      <ShareProfileButton profileUrl={profileUrl} displayName={displayName} issuerId={educator.wallet_address} />
+                      <ShareProfileButton profileUrl={profileUrl} displayName={displayName} issuerWallet={educator.wallet_address} />
                     </div>
                   </div>
                 </article>

--- a/frontend/src/pages/EducatorProfile.tsx
+++ b/frontend/src/pages/EducatorProfile.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { P } from '@/components/profile/palette';
 import { GrainOverlay } from '@/components/profile/GrainOverlay';
 import { resolveIpfs } from '@/lib/ipfs';
+import { ShareProfileButton } from '@/components/ShareProfileButton';
 
 const HackChainLogo = '/images/logoHackchain2.webp';
 
@@ -283,7 +284,7 @@ const EducatorProfile = () => {
   const contractAddress = import.meta.env.VITE_CONTRACT_ADDRESS as string | undefined;
   const hasAnyLinks =
     !!educator?.website_url || !!educator?.linkedin_url || !!educator?.twitter_url;
-
+  const profileUrl = `${window.location.origin}/issuers/${wallet}`;
   return (
     <Layout>
       <GrainOverlay />
@@ -460,6 +461,7 @@ const EducatorProfile = () => {
                         />
                         {t('since')} {formatDate(educator.joined_at)}
                       </div>
+                      <ShareProfileButton profileUrl={profileUrl} displayName={displayName} issuerId={educator.wallet_address} />
                     </div>
                   </div>
                 </article>
@@ -590,7 +592,7 @@ const EducatorProfile = () => {
                 >
                   <div className="space-y-3">
                     <div
-                      className="flex items-center justify-between gap-3 rounded-xl px-4 py-3"
+                      className="flex flex-col gap-3 rounded-xl px-4 py-3 sm:flex-row sm:items-center justify-between"
                       style={{ backgroundColor: P.surface, border: `1px solid ${P.border}` }}
                     >
                       <div className="min-w-0">
@@ -600,7 +602,7 @@ const EducatorProfile = () => {
                         >
                           {t('educatorProfile.issuerWalletLabel')}
                         </div>
-                        <div className="text-sm font-mono truncate" style={{ color: P.textSecondary }}>
+                        <div className="text-sm font-mono break-all" style={{ color: P.textSecondary }}>
                           {educator.wallet_address}
                         </div>
                       </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -150,6 +150,14 @@ async function del<T>(path: string, body?: unknown): Promise<T> {
   }));
 }
 
+async function registerProfileShare(issuerId: string): Promise<void> {
+  try {
+    await post<void>(`/api/issuers/${issuerId}/share`);
+  } catch {
+    // Silent fail: sharing already happened client-side, the counter is secondary
+  }
+}
+
 export const api = {
   get,
   post,
@@ -159,4 +167,5 @@ export const api = {
   getPublic,
   upload,
   uploadPublic,
+  registerProfileShare,
 } as const;

--- a/frontend/src/test/useShareProfile.test.ts
+++ b/frontend/src/test/useShareProfile.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildShareUrl,
+  buildShareLinks,
+  createQrDataUrl,
+} from '@/hooks/useShareProfile';
+
+describe('buildShareUrl', () => {
+  const profileUrl = 'https://example.com/profile/ada';
+  const displayName = 'Ada';
+
+  it('builds the WhatsApp share URL', () => {
+    const url = buildShareUrl('whatsapp', profileUrl, displayName);
+
+    expect(url.startsWith('https://wa.me/?text=')).toBe(true);
+    expect(url).toContain(encodeURIComponent(profileUrl));
+  });
+
+  it('builds the LinkedIn share URL', () => {
+    const url = buildShareUrl('linkedin', profileUrl, displayName);
+
+    expect(url.startsWith('https://www.linkedin.com/sharing/share-offsite/?url=')).toBe(true);
+    expect(url).toContain(encodeURIComponent(profileUrl));
+  });
+
+  it('builds the Twitter share URL', () => {
+    const url = buildShareUrl('twitter', profileUrl, displayName);
+
+    expect(url.startsWith('https://twitter.com/intent/tweet?text=')).toBe(true);
+    expect(url).toContain(encodeURIComponent(profileUrl));
+  });
+});
+
+describe('buildShareLinks', () => {
+  it('returns share links for every supported platform', () => {
+    const links = buildShareLinks(
+      'https://example.com/profile/ada',
+      'Ada',
+    );
+
+    expect(links.whatsapp).toContain('wa.me');
+    expect(links.linkedin).toContain('linkedin.com');
+    expect(links.twitter).toContain('twitter.com');
+  });
+
+  it('encodes profile URLs containing spaces and query parameters', () => {
+    const profileUrl =
+      'https://example.com/profile/Ada Lovelace?tab=certificates';
+
+    const links = buildShareLinks(profileUrl, 'Ada Lovelace');
+
+    expect(links.whatsapp).toContain(encodeURIComponent(profileUrl));
+    expect(links.linkedin).toContain(encodeURIComponent(profileUrl));
+    expect(links.twitter).toContain(encodeURIComponent(profileUrl));
+  });
+});
+
+describe('createQrDataUrl', () => {
+  const profileUrl = 'https://example.com/profile/ada';
+
+  it('returns the same QR URL for the same input', () => {
+    const first = createQrDataUrl(profileUrl, 0);
+    const second = createQrDataUrl(profileUrl, 0);
+
+    expect(first).toBe(second);
+  });
+
+  it('returns a different QR URL when the cache-busting value changes', () => {
+    const first = createQrDataUrl(profileUrl, 0);
+    const second = createQrDataUrl(profileUrl, 1);
+
+    expect(first).not.toBe(second);
+  });
+
+  it('includes the encoded profile URL', () => {
+    const url = createQrDataUrl(profileUrl, 0);
+
+    expect(url).toContain(encodeURIComponent(profileUrl));
+  });
+
+  it('includes the cache-busting parameter', () => {
+    const url = createQrDataUrl(profileUrl, 7);
+
+    expect(url).toContain('&t=7');
+  });
+
+  it('includes the QR size parameter', () => {
+    const url = createQrDataUrl(profileUrl, 0);
+
+    expect(url).toContain('size=180x180');
+  });
+});

--- a/frontend/src/test/useShareProfile.test.ts
+++ b/frontend/src/test/useShareProfile.test.ts
@@ -1,9 +1,25 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
 import {
   buildShareUrl,
   buildShareLinks,
   createQrDataUrl,
+  useShareProfile,
 } from '@/hooks/useShareProfile';
+
+import { api } from '@/services/api';
+
+vi.mock('@/services/api', () => ({
+  api: {
+    registerProfileShare: vi.fn(),
+  },
+}));
+
+const mockedApi = vi.mocked(api);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 describe('buildShareUrl', () => {
   const profileUrl = 'https://example.com/profile/ada';
@@ -89,4 +105,101 @@ describe('createQrDataUrl', () => {
 
     expect(url).toContain('size=180x180');
   });
+});
+
+describe('useShareProfile', () => {
+  it('sets the QR status to success when handleQrLoad is called', () => {
+    const { result } = renderHook(() =>
+      useShareProfile(
+        'https://example.com/profile/ada',
+        'Ada',
+        '0xabc',
+      ),
+    );
+
+    expect(result.current.qrStatus).toBe('loading');
+
+    act(() => {
+      result.current.handleQrLoad();
+    });
+
+    expect(result.current.qrStatus).toBe('success');
+  });
+});
+
+it('sets the QR status to error when handleQrError is called', () => {
+  const { result } = renderHook(() =>
+    useShareProfile(
+      'https://example.com/profile/ada',
+      'Ada',
+      '0xabc',
+    ),
+  );
+
+  expect(result.current.qrStatus).toBe('loading');
+
+  act(() => {
+    result.current.handleQrError();
+  });
+
+  expect(result.current.qrStatus).toBe('error');
+});
+
+it('retries the QR by resetting the status and changing the QR URL', () => {
+  const { result } = renderHook(() =>
+    useShareProfile(
+      'https://example.com/profile/ada',
+      'Ada',
+      '0xabc',
+    ),
+  );
+
+  const initialQrUrl = result.current.qrUrl;
+
+  act(() => {
+    result.current.handleQrError();
+  });
+
+  expect(result.current.qrStatus).toBe('error');
+
+  act(() => {
+    result.current.retryQr();
+  });
+
+  expect(result.current.qrStatus).toBe('loading');
+  expect(result.current.qrUrl).not.toBe(initialQrUrl);
+});
+
+it('registers a profile share when copying the link', () => {
+  const { result } = renderHook(() =>
+    useShareProfile(
+      'https://example.com/profile/ada',
+      'Ada',
+      '0xabc',
+    ),
+  );
+
+  act(() => {
+    result.current.handleLinkCopy();
+  });
+
+  expect(mockedApi.registerProfileShare).toHaveBeenCalledWith('0xabc');
+  expect(mockedApi.registerProfileShare).toHaveBeenCalledTimes(1);
+});
+
+it('registers a profile share when opening a social link', () => {
+  const { result } = renderHook(() =>
+    useShareProfile(
+      'https://example.com/profile/ada',
+      'Ada',
+      '0xabc',
+    ),
+  );
+
+  act(() => {
+    result.current.handleSocialClick();
+  });
+
+  expect(mockedApi.registerProfileShare).toHaveBeenCalledWith('0xabc');
+  expect(mockedApi.registerProfileShare).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
## Why

Educator profiles did not provide an easy way for users to share them or track how often they were shared. This feature improves profile visibility by allowing users to share profiles through multiple channels while recording share events in the backend.

## What

* Added the `ShareProfileButton` component to the educator profile page.
* Implemented a share dialog with:

  * Copy profile link.
  * Share via WhatsApp, LinkedIn and X (Twitter).
  * QR code for the educator profile.
* Added QR code loading, success and error states with retry support.
* Integrated the frontend with the `POST /api/issuers/:wallet/share` endpoint to register profile share events.
* Ensured that sharing is not interrupted if the share counter request fails.

## Impact

* Users can easily share educator profiles through multiple platforms.
* Every share action is recorded by the backend, increasing the profile `share_count`.
* Improves the overall sharing experience while maintaining a resilient user flow.

## Verification (local)

* Verified that the Share button opens the sharing dialog.
* Verified that the profile link can be copied successfully.
* Verified that WhatsApp, LinkedIn and X open with the correct share URL.
* Verified that the QR code loads correctly and handles loading and error states.
* Verified in the browser Network tab that `POST /api/issuers/:wallet/share` returns **200 OK** and increments the share counter successfully.
