### PR TITLE
fix(frontend): correct share link route on educator profile

### DIFF
--- a/frontend/src/pages/EducatorProfile.tsx
+++ b/frontend/src/pages/EducatorProfile.tsx
@@ -284,7 +284,7 @@ const EducatorProfile = () => {
   const contractAddress = import.meta.env.VITE_CONTRACT_ADDRESS as string | undefined;
   const hasAnyLinks =
     !!educator?.website_url || !!educator?.linkedin_url || !!educator?.twitter_url;
-  const profileUrl = `${window.location.origin}/issuers/${wallet}`;
+  const profileUrl = `${window.location.origin}/educator/${wallet}`;
   return (
     <Layout>
       <GrainOverlay />


### PR DESCRIPTION
Why: the share button generated links to /issuers/:wallet, a path that only exists as a backend API prefix — the frontend route is /educator/:wallet, so every shared link and QR code 404'd in production.
What: builds profileUrl from /educator/${wallet} to match the router in App.tsx.
Impact: copied links, social shares, and QR codes for educator profiles now resolve correctly instead of 404ing.