### PR TITLE
feat(backend): certificate logo endpoint + ClassRequest lock on certificate creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ npm run migrate:harjoot-phase1        # adds payment, treasury, talent-invitatio
 npm run migrate:referrals-phase1      # adds referrals, incentives_pool_ledger tables + referral_code column
 npm run migrate:issuer-share-count    # adds share_count column to issuers
 npm run migrate:certificate-share-count  # adds share_count column to certificates
+npm run migrate:issuer-certificate-logo  # adds certificate_logo_url column to issuers
 ```
 
 Each script is idempotent — safe to run more than once.

--- a/backend/documentacionAPI.md
+++ b/backend/documentacionAPI.md
@@ -426,6 +426,15 @@ Registra un certificado ya emitido en blockchain dentro de la base de datos. Val
 | `blockchain_tx_hash` | `string` | ❌ | Hash de la transacción en blockchain |
 | `token_id` | `string` \| `number` | ❌ | ID del token NFT |
 | `issue_date` | `string` | ❌ | Fecha de emisión |
+| `class_request_id` | `number` | ❌ | ID de la `ClassRequest` de la que proviene el certificado (clase personalizada completada) |
+
+Cuando se envía `class_request_id`, el servidor valida contra la `ClassRequest` real: que
+pertenezca al emisor autenticado, que `student_wallet_address` coincida, y que `title` coincida
+con `class_name` (solo si `class_name` no es nulo — si la clase no tenía nombre, cualquier título
+es válido). Cualquier discrepancia (incluyendo `class_request_id` inexistente o perteneciente a
+otro emisor) responde `409` con el mismo mensaje genérico, para no revelar mediante el código de
+estado qué IDs existen en el sistema; la causa específica del rechazo queda en el log del
+servidor para detección de abuso.
 
 **Respuestas**
 
@@ -434,6 +443,7 @@ Registra un certificado ya emitido en blockchain dentro de la base de datos. Val
 | `201` | Certificado registrado correctamente |
 | `400` | Campos obligatorios faltantes o wallet inválida |
 | `404` | Emisor no registrado como autorizado |
+| `409` | `class_request_id` no coincide (inexistente, de otro emisor, o datos que no coinciden) |
 | `500` | Error interno del servidor |
 
 **Ejemplo de respuesta exitosa**

--- a/backend/documentacionAPI.md
+++ b/backend/documentacionAPI.md
@@ -674,6 +674,40 @@ Envía una transacción a la blockchain para autorizar a una wallet como emisor 
 
 ---
 
+### PATCH `/api/issuers/me/certificate-logo`
+
+Actualiza el logo de certificados del emisor autenticado (URI `ipfs://` únicamente). Separado del
+`photo_url` de perfil (`PATCH /api/issuers/me/photo`): este logo se estampa en los certificados
+emitidos, no se muestra en la tarjeta de perfil público.
+
+**Autenticación**: Requerida — Bearer token o cookie de sesión; solo cuentas con rol `issuer`.
+
+**Body**
+
+| Campo | Tipo | Requerido | Descripción |
+|---|---|---|---|
+| `certificate_logo_url` | `string` | ✅ | URI `ipfs://<cid>` del logo |
+
+**Respuestas**
+
+| Código | Descripción |
+|---|---|
+| `200` | Logo actualizado; retorna `certificate_logo_url` |
+| `400` | `certificate_logo_url` faltante o no es una URI `ipfs://` válida |
+| `403` | La cuenta autenticada no es un emisor |
+| `404` | Emisor no encontrado |
+| `500` | Error interno del servidor |
+
+**Ejemplo de respuesta exitosa**
+
+```json
+{
+  "certificate_logo_url": "ipfs://<cid>"
+}
+```
+
+---
+
 ### GET `/api/issuers/:wallet_address`
 
 Obtiene el perfil público de un emisor por su wallet address. No expone email ni otros datos

--- a/backend/models/issuers.js
+++ b/backend/models/issuers.js
@@ -19,6 +19,7 @@ module.exports = (sequelize, DataTypes) => {
     certificates_issued: { type: DataTypes.INTEGER, defaultValue: 0, allowNull: false },
     share_count: { type: DataTypes.INTEGER, defaultValue: 0, allowNull: false },
     photo_url: { type: DataTypes.STRING(500), allowNull: true },
+    certificate_logo_url: { type: DataTypes.STRING(500), allowNull: true },
     bio: { type: DataTypes.TEXT, allowNull: true },
     knowledge_areas: { type: DataTypes.JSONB, allowNull: true, defaultValue: [] },
     website_url: { type: DataTypes.STRING(500), allowNull: true },

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "migrate:issuer-profile": "node scripts/migrate-issuer-profile.js",
     "migrate:issuer-share-count": "node scripts/migrate-issuer-share-count.js",
     "migrate:certificate-share-count": "node scripts/migrate-certificate-share-count.js",
+    "migrate:issuer-certificate-logo": "node scripts/migrate-issuer-certificate-logo.js",
     "migrate:harjoot-phase1": "node scripts/migrate-harjoot-phase1.js",
     "migrate:referrals-phase1": "node scripts/migrate-referrals-phase1.js"
   },

--- a/backend/routes/certificates.js
+++ b/backend/routes/certificates.js
@@ -477,6 +477,42 @@ router.post("/database", authenticate, async (req, res) => {
       ? (() => { const n = parseInt(class_request_id, 10); return Number.isFinite(n) && n > 0 ? n : null; })()
       : null;
 
+    // 3.5 Lock: when a class_request_id is provided, the certificate being
+    // registered must actually belong to that class. Otherwise an issuer
+    // could tag any certificate as "from a completed class" by sending an
+    // arbitrary id. The API always answers 409 for every mismatch reason
+    // (not found / other issuer's class / wallet or title mismatch) so a
+    // caller can't use the status code to probe which ids exist in the
+    // system — but the server log keeps the real reason for abuse detection.
+    if (parsedClassRequestId) {
+      const classRequest = await db.ClassRequest.findByPk(parsedClassRequestId);
+      const CERT_LOCK_MISMATCH = {
+        error: "Los datos del certificado no coinciden con la solicitud de clase",
+      };
+
+      if (!classRequest) {
+        console.warn(`[cert-lock] class_request_id ${parsedClassRequestId} not found, attempted by ${cleanIssuerWallet}`);
+        return res.status(409).json(CERT_LOCK_MISMATCH);
+      }
+
+      if (classRequest.issuer_wallet_address.toLowerCase() !== cleanIssuerWallet) {
+        console.warn(`[cert-lock] class_request_id ${parsedClassRequestId} belongs to another issuer, attempted by ${cleanIssuerWallet}`);
+        return res.status(409).json(CERT_LOCK_MISMATCH);
+      }
+
+      if (classRequest.student_wallet_address.toLowerCase() !== cleanStudentWallet) {
+        console.warn(`[cert-lock] class_request_id ${parsedClassRequestId} student wallet mismatch, attempted by ${cleanIssuerWallet}`);
+        return res.status(409).json(CERT_LOCK_MISMATCH);
+      }
+
+      // class_name is nullable (classes without a name) — nothing real to
+      // compare the title against, so any title is accepted in that case.
+      if (classRequest.class_name != null && String(title).trim() !== String(classRequest.class_name).trim()) {
+        console.warn(`[cert-lock] class_request_id ${parsedClassRequestId} title mismatch, attempted by ${cleanIssuerWallet}`);
+        return res.status(409).json(CERT_LOCK_MISMATCH);
+      }
+    }
+
     // 4. Creación del certificado
     const certificate = await Certificate.create({
       student_wallet_address: cleanStudentWallet,

--- a/backend/routes/issuers.js
+++ b/backend/routes/issuers.js
@@ -18,6 +18,7 @@ const { getIssuerApprovalStatus } = require("../usecases/issuers/getIssuerApprov
 const { reapplyForApproval } = require("../usecases/issuers/reapplyForApproval");
 const { updateOwnIssuerProfile } = require("../usecases/issuers/updateOwnIssuerProfile");
 const { updateIssuerPhoto } = require("../usecases/issuers/updateIssuerPhoto");
+const { updateIssuerCertificateLogo } = require("../usecases/issuers/updateIssuerCertificateLogo");
 const { getPublicIssuerProfile } = require("../usecases/issuers/getPublicIssuerProfile");
 const { updatePublicIssuerProfile } = require("../usecases/issuers/updatePublicIssuerProfile");
 const { deleteOwnIssuerAccount } = require("../usecases/issuers/deleteOwnIssuerAccount");
@@ -264,6 +265,28 @@ router.patch("/me/photo", authenticate, async (req, res) => {
   } catch (err) {
     console.error("Failed to update issuer photo:", err);
     res.status(500).json({ error: "Failed to update photo" });
+  }
+});
+
+// PATCH /api/issuers/me/certificate-logo — update own certificate logo (ipfs:// URI only)
+// Separate from /me/photo: this logo is stamped on issued certificates, the
+// profile photo is only shown on the public profile card.
+router.patch("/me/certificate-logo", authenticate, async (req, res) => {
+  if (req.auth.role !== "issuer") {
+    return res.status(403).json({ error: "Only educator accounts can update this profile" });
+  }
+
+  try {
+    const result = await updateIssuerCertificateLogo({
+      models: { Issuer },
+      wallet: req.auth.wallet,
+      certificateLogoUrl: req.body.certificate_logo_url,
+    });
+    if (!result.ok) return res.status(result.httpStatus).json({ error: result.message });
+    return res.json(result.data);
+  } catch (err) {
+    console.error("Failed to update issuer certificate logo:", err);
+    res.status(500).json({ error: "Failed to update certificate logo" });
   }
 });
 

--- a/backend/scripts/migrate-issuer-certificate-logo.js
+++ b/backend/scripts/migrate-issuer-certificate-logo.js
@@ -1,0 +1,34 @@
+require("dotenv").config({ path: require("path").join(__dirname, "../.env") });
+
+const { sequelize } = require("../models");
+const { DataTypes } = require("sequelize");
+
+async function run() {
+  const q = sequelize.getQueryInterface();
+  const columns = await q.describeTable("issuers");
+
+  const toAdd = [
+    {
+      name: "certificate_logo_url",
+      missing: !columns.certificate_logo_url,
+      def: { type: DataTypes.STRING(500), allowNull: true },
+    },
+  ];
+
+  for (const col of toAdd) {
+    if (col.missing) {
+      await q.addColumn("issuers", col.name, col.def);
+      console.log(`Added column: ${col.name}`);
+    } else {
+      console.log(`Column already exists: ${col.name}`);
+    }
+  }
+
+  await sequelize.close();
+  console.log("Migration complete.");
+}
+
+run().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});

--- a/backend/tests/certificates.test.js
+++ b/backend/tests/certificates.test.js
@@ -327,3 +327,251 @@ describe("POST /api/certificates/:id/share", () => {
     expect(res.body).toHaveProperty("error");
   });
 });
+
+// POST /api/certificates/database — class_request_id lock
+//
+// When a certificate is registered with a class_request_id, the server must
+// confirm it actually matches that ClassRequest (owner, student wallet, and
+// title vs class_name) before creating it. Every mismatch reason answers the
+// same 409 — see documentacionAPI.md for why the status code is uniform.
+describe("POST /api/certificates/database — class_request_id lock", () => {
+  let sequelize;
+  let User, Issuer, Student, Recruiter, Certificate, UserSession, ClassRequest, IssuerClass;
+  let app;
+
+  const makeWallet = () => "0x" + crypto.randomBytes(20).toString("hex");
+
+  const seedIssuerAndStudent = async () => {
+    const issuerWallet = makeWallet();
+    const studentWallet = makeWallet();
+
+    await User.create({
+      wallet_address: issuerWallet,
+      role: "issuer",
+      name: "Edu",
+      nonce: crypto.randomBytes(16).toString("hex"),
+      educator_approval_status: "approved",
+    });
+    await Issuer.create({
+      wallet_address: issuerWallet,
+      organization_name: "Org",
+      certificates_issued: 0,
+    });
+    await User.create({
+      wallet_address: studentWallet,
+      role: "student",
+      name: "Stu",
+      nonce: crypto.randomBytes(16).toString("hex"),
+    });
+    await Student.create({ wallet_address: studentWallet });
+
+    return { issuerWallet, studentWallet };
+  };
+
+  const seedClassRequest = async ({ issuerWallet, studentWallet, className, status = "confirmed" }) =>
+    ClassRequest.create({
+      student_wallet_address: studentWallet,
+      issuer_wallet_address: issuerWallet,
+      requested_date: "2026-07-20",
+      start_time: "10:00",
+      duration_minutes: 60,
+      class_name: className ?? null,
+      status,
+    });
+
+  const issueSession = async (wallet, role) => {
+    const existing = await User.findOne({ where: { wallet_address: wallet } });
+    if (!existing) {
+      await User.create({
+        wallet_address: wallet,
+        role,
+        name: "Bystander",
+        nonce: crypto.randomBytes(16).toString("hex"),
+      });
+    }
+    await UserSession.create({
+      id: crypto.randomBytes(16).toString("hex"),
+      wallet_address: wallet,
+      expires_at: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    return jwt.sign({ wallet, role }, process.env.JWT_SECRET, { expiresIn: "15m" });
+  };
+
+  const postCertificate = (token, body) =>
+    request(app)
+      .post("/api/certificates/database")
+      .set("Authorization", `Bearer ${token}`)
+      .send(body);
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", { logging: false });
+    const DataTypes = SequelizePkg.DataTypes;
+
+    User = require("../models/users")(sequelize, DataTypes);
+    Student = sequelize.define("Student", {
+      id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+      wallet_address: { type: DataTypes.STRING(42), allowNull: false, unique: true },
+    }, {
+      tableName: "students",
+      underscored: true,
+      timestamps: true,
+      createdAt: "created_at",
+      updatedAt: "updated_at",
+    });
+    Issuer = require("../models/issuers")(sequelize, DataTypes);
+    Recruiter = require("../models/recruiters")(sequelize, DataTypes);
+    Certificate = require("../models/certificates")(sequelize, DataTypes);
+    UserSession = require("../models/userSessions")(sequelize, DataTypes);
+    ClassRequest = require("../models/classRequests")(sequelize, DataTypes);
+    IssuerClass = require("../models/issuerClasses")(sequelize, DataTypes);
+
+    const modelsMock = {
+      User, Student, Issuer, Recruiter, Certificate, UserSession, ClassRequest, IssuerClass,
+      sequelize,
+      Sequelize: SequelizePkg,
+    };
+
+    Object.values(modelsMock).forEach((m) => m?.associate?.(modelsMock));
+
+    sequelize.random = () => SequelizePkg.literal("RANDOM()");
+
+    await sequelize.sync({ force: true });
+
+    jest.isolateModules(() => {
+      jest.doMock("../models", () => modelsMock);
+      jest.doMock("../services/emailService", () => ({
+        notifyTalentCertificateIssued: jest.fn().mockResolvedValue(undefined),
+      }));
+      const certificatesRoute = require("../routes/certificates");
+      app = express();
+      app.use(bodyParser.json());
+      app.use("/api/certificates", certificatesRoute);
+    });
+  });
+
+  afterAll(async () => {
+    jest.resetModules();
+    if (sequelize) await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+  });
+
+  test("409 when class_request_id does not exist", async () => {
+    const { issuerWallet, studentWallet } = await seedIssuerAndStudent();
+    const token = await issueSession(issuerWallet, "issuer");
+
+    const res = await postCertificate(token, {
+      student_wallet_address: studentWallet,
+      issuer_wallet_address: issuerWallet,
+      title: "Clase Personalizada",
+      class_request_id: 999999,
+    }).expect(409);
+
+    expect(res.body).toHaveProperty("error");
+  });
+
+  test("409 when the class_request_id belongs to another issuer", async () => {
+    const { issuerWallet, studentWallet } = await seedIssuerAndStudent();
+    const { issuerWallet: otherIssuerWallet } = await seedIssuerAndStudent();
+    const classRequest = await seedClassRequest({
+      issuerWallet: otherIssuerWallet,
+      studentWallet,
+      className: "Clase Personalizada",
+    });
+    const token = await issueSession(issuerWallet, "issuer");
+
+    const res = await postCertificate(token, {
+      student_wallet_address: studentWallet,
+      issuer_wallet_address: issuerWallet,
+      title: "Clase Personalizada",
+      class_request_id: classRequest.id,
+    }).expect(409);
+
+    expect(res.body).toHaveProperty("error");
+  });
+
+  test("409 when student_wallet_address does not match the ClassRequest", async () => {
+    const { issuerWallet, studentWallet } = await seedIssuerAndStudent();
+    const otherStudentWallet = makeWallet();
+    const classRequest = await seedClassRequest({
+      issuerWallet,
+      studentWallet,
+      className: "Clase Personalizada",
+    });
+    const token = await issueSession(issuerWallet, "issuer");
+
+    const res = await postCertificate(token, {
+      student_wallet_address: otherStudentWallet,
+      issuer_wallet_address: issuerWallet,
+      title: "Clase Personalizada",
+      class_request_id: classRequest.id,
+    }).expect(409);
+
+    expect(res.body).toHaveProperty("error");
+  });
+
+  test("409 when title does not match a non-null class_name", async () => {
+    const { issuerWallet, studentWallet } = await seedIssuerAndStudent();
+    const classRequest = await seedClassRequest({
+      issuerWallet,
+      studentWallet,
+      className: "Clase Personalizada",
+    });
+    const token = await issueSession(issuerWallet, "issuer");
+
+    const res = await postCertificate(token, {
+      student_wallet_address: studentWallet,
+      issuer_wallet_address: issuerWallet,
+      title: "Un título distinto",
+      class_request_id: classRequest.id,
+    }).expect(409);
+
+    expect(res.body).toHaveProperty("error");
+  });
+
+  test("201 when student_wallet_address and title match the ClassRequest", async () => {
+    const { issuerWallet, studentWallet } = await seedIssuerAndStudent();
+    const classRequest = await seedClassRequest({
+      issuerWallet,
+      studentWallet,
+      className: "Clase Personalizada",
+    });
+    const token = await issueSession(issuerWallet, "issuer");
+
+    const res = await postCertificate(token, {
+      student_wallet_address: studentWallet,
+      issuer_wallet_address: issuerWallet,
+      title: "Clase Personalizada",
+      certificate_hash: crypto.randomBytes(16).toString("hex"),
+      token_id: "1",
+      issue_date: "2026-07-20",
+      class_request_id: classRequest.id,
+    }).expect(201);
+
+    expect(res.body).toHaveProperty("id");
+  });
+
+  test("201 with any title when the ClassRequest has no class_name", async () => {
+    const { issuerWallet, studentWallet } = await seedIssuerAndStudent();
+    const classRequest = await seedClassRequest({
+      issuerWallet,
+      studentWallet,
+      className: null,
+    });
+    const token = await issueSession(issuerWallet, "issuer");
+
+    const res = await postCertificate(token, {
+      student_wallet_address: studentWallet,
+      issuer_wallet_address: issuerWallet,
+      title: "Cualquier título elegido por el educador",
+      certificate_hash: crypto.randomBytes(16).toString("hex"),
+      token_id: "1",
+      issue_date: "2026-07-20",
+      class_request_id: classRequest.id,
+    }).expect(201);
+
+    expect(res.body).toHaveProperty("id");
+  });
+});

--- a/backend/tests/issuers-profile.test.js
+++ b/backend/tests/issuers-profile.test.js
@@ -112,6 +112,7 @@ describe("Issuer profile routes", () => {
       organization_name: "HackAcademy",
       bio: null,
       photo_url: null,
+      certificate_logo_url: null,
       knowledge_areas: [],
       wallet_address: ISSUER,
       email: "prof@x.com",

--- a/backend/usecases/issuers/__tests__/getOwnIssuerProfile.test.js
+++ b/backend/usecases/issuers/__tests__/getOwnIssuerProfile.test.js
@@ -52,6 +52,7 @@ describe("getOwnIssuerProfile", () => {
       organization_name: "HackAcademy",
       bio: "bio",
       photo_url: null,
+      certificate_logo_url: null,
       knowledge_areas: ["pentest"],
       wallet_address: ISSUER,
       email: "prof@x.com",

--- a/backend/usecases/issuers/__tests__/updateIssuerCertificateLogo.test.js
+++ b/backend/usecases/issuers/__tests__/updateIssuerCertificateLogo.test.js
@@ -1,0 +1,51 @@
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+const { updateIssuerCertificateLogo } = require("../updateIssuerCertificateLogo");
+
+jest.setTimeout(15000);
+
+const ISSUER = "0x" + "cc".repeat(20);
+
+describe("updateIssuerCertificateLogo", () => {
+  let sequelize, models;
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", { logging: false });
+    const { DataTypes } = SequelizePkg;
+    const User = require("../../../models/users")(sequelize, DataTypes);
+    const Student = require("../../../models/students")(sequelize, DataTypes);
+    const Issuer = require("../../../models/issuers")(sequelize, DataTypes);
+    const Recruiter = require("../../../models/recruiters")(sequelize, DataTypes);
+    const Certificate = require("../../../models/certificates")(sequelize, DataTypes);
+    const UserSession = require("../../../models/userSessions")(sequelize, DataTypes);
+
+    models = { User, Student, Issuer, Recruiter, Certificate, UserSession, sequelize, Sequelize: SequelizePkg };
+    Object.values(models).forEach((m) => m?.associate && m.associate(models));
+    await sequelize.sync({ force: true });
+    await models.User.create({ wallet_address: ISSUER, role: "issuer", name: "Prof", nonce: crypto.randomBytes(16).toString("hex") });
+    await models.Issuer.create({ wallet_address: ISSUER, organization_name: "HackAcademy" });
+  });
+
+  afterAll(() => sequelize.close());
+
+  test("returns CERTIFICATE_LOGO_URL_REQUIRED when missing", async () => {
+    const result = await updateIssuerCertificateLogo({ models, wallet: ISSUER });
+    expect(result.code).toBe("CERTIFICATE_LOGO_URL_REQUIRED");
+  });
+
+  test("rejects a non-ipfs URL", async () => {
+    const result = await updateIssuerCertificateLogo({ models, wallet: ISSUER, certificateLogoUrl: "https://evil.com/x.png" });
+    expect(result.code).toBe("INVALID_CERTIFICATE_LOGO_URL");
+  });
+
+  test("returns ISSUER_NOT_FOUND for an unknown wallet", async () => {
+    const result = await updateIssuerCertificateLogo({ models, wallet: "0x" + "ff".repeat(20), certificateLogoUrl: "ipfs://abc123" });
+    expect(result.code).toBe("ISSUER_NOT_FOUND");
+  });
+
+  test("accepts a valid ipfs:// URI", async () => {
+    const result = await updateIssuerCertificateLogo({ models, wallet: ISSUER, certificateLogoUrl: "ipfs://abc123" });
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({ certificate_logo_url: "ipfs://abc123" });
+  });
+});

--- a/backend/usecases/issuers/getOwnIssuerProfile.js
+++ b/backend/usecases/issuers/getOwnIssuerProfile.js
@@ -22,6 +22,7 @@ async function getOwnIssuerProfile({ models, wallet }) {
       organization_name: issuer.organization_name,
       bio: issuer.bio,
       photo_url: issuer.photo_url,
+      certificate_logo_url: issuer.certificate_logo_url,
       knowledge_areas: issuer.knowledge_areas ?? [],
       wallet_address: issuer.wallet_address,
       email: issuer.User?.email ?? null,

--- a/backend/usecases/issuers/updateIssuerCertificateLogo.js
+++ b/backend/usecases/issuers/updateIssuerCertificateLogo.js
@@ -1,0 +1,42 @@
+const IPFS_URI_RE = /^ipfs:\/\/[a-zA-Z0-9]+$/;
+
+/**
+ * Updates the authenticated issuer's certificate logo (ipfs:// URI only).
+ * Separate from the profile photo (updateIssuerPhoto) — this logo is stamped
+ * on issued certificates, not shown on the public profile card.
+ * Returns a result object — never throws on business errors.
+ */
+async function updateIssuerCertificateLogo({ models, wallet, certificateLogoUrl }) {
+  if (!models || !wallet) {
+    throw new TypeError("updateIssuerCertificateLogo requires { models, wallet }");
+  }
+
+  if (!certificateLogoUrl || typeof certificateLogoUrl !== "string") {
+    return {
+      ok: false,
+      code: "CERTIFICATE_LOGO_URL_REQUIRED",
+      httpStatus: 400,
+      message: "certificate_logo_url is required",
+    };
+  }
+
+  if (!IPFS_URI_RE.test(certificateLogoUrl)) {
+    return {
+      ok: false,
+      code: "INVALID_CERTIFICATE_LOGO_URL",
+      httpStatus: 400,
+      message: "certificate_logo_url must be a valid ipfs:// URI",
+    };
+  }
+
+  const issuer = await models.Issuer.findOne({ where: { wallet_address: wallet.toLowerCase() } });
+  if (!issuer) {
+    return { ok: false, code: "ISSUER_NOT_FOUND", httpStatus: 404, message: "Issuer not found" };
+  }
+
+  await issuer.update({ certificate_logo_url: certificateLogoUrl });
+
+  return { ok: true, data: { certificate_logo_url: issuer.certificate_logo_url } };
+}
+
+module.exports = { updateIssuerCertificateLogo };


### PR DESCRIPTION
## Why
Segundo ticket del bloque de automatización de emisión de certificado (Héctor, deadline 2026-07-22). Parte de backend: (1) los educadores necesitan subir un logo de certificados separado de su foto de perfil, para que el frontend (Luis) lo autocomplete en el formulario de emisión; (2) cuando un certificado se registra desde una clase completada (`class_request_id`), el servidor no validaba que los datos coincidieran con esa `ClassRequest` real — un emisor podía enganchar cualquier certificado a cualquier clase (propia o ajena) enviando un id arbitrario.

## What
- `feat(backend): add certificate_logo_url column to Issuer` — columna nullable `certificate_logo_url` en `Issuer` (separada de `photo_url`), migración idempotente `migrate-issuer-certificate-logo.js` (mismo patrón que `migrate-issuer-share-count.js`), script npm y README actualizados.
- `feat(backend): add updateIssuerCertificateLogo usecase and PATCH /me/certificate-logo` — usecase clon de `updateIssuerPhoto` (valida `ipfs://`, result-object), endpoint `PATCH /api/issuers/me/certificate-logo` (solo rol `issuer`), expuesto en `GET /api/issuers/me` vía `getOwnIssuerProfile`. Doc en `documentacionAPI.md`.
- `feat(backend): lock certificate creation to matching ClassRequest` — en `POST /api/certificates/database`, cuando llega `class_request_id`, valida que pertenezca al emisor autenticado, que `student_wallet_address` coincida, y que `title` coincida con `class_name` (**solo si `class_name` no es null** — decisión de Héctor: si la clase no tenía nombre no hay nada real contra qué comparar). Cualquier mismatch (inexistente / de otro emisor / datos distintos) responde **409 uniforme** al cliente (mismo mensaje en los 4 casos, para no revelar qué IDs existen), pero el servidor **distingue la causa en el log** (`console.warn("[cert-lock] ...")`) — pedido explícito de Héctor para detectar patrones de abuso sin filtrar nada por la API pública.

## Impact
Todo aditivo. El candado solo se activa cuando se envía `class_request_id`; el flujo existente sin ese campo no cambia. Hay que correr `npm run migrate:issuer-certificate-logo` en el deploy.

Se actualizaron 2 tests preexistentes (`usecases/issuers/__tests__/getOwnIssuerProfile.test.js`, `tests/issuers-profile.test.js`) que esperaban un objeto exacto en `GET /me` — consecuencia directa y esperada de exponer `certificate_logo_url` ahí, no un fix de bug.

Nota de alcance (Héctor, Discord 2026-07-16): este candado valida contra `ClassRequest`; cuando exista el modelo de cursos con su propio flujo de finalización, este mismo patrón se replica apuntando a esa entidad nueva, sin modificar esta validación.

## Verification (local)
- Tests nuevos: `updateIssuerCertificateLogo.test.js` (4/4), 6 casos nuevos del candado en `tests/certificates.test.js` (4 rechazos 409 + 2 éxitos 201, incluyendo `class_name` null).
- Suite completa: **808/815 pass**. Los 7 fallos son los preexistentes de siempre (`register`, `referralModels` ×5, `precheckCertificate`) — confirmados iguales a los de PR #93, ajenos a este cambio.
- Sin dump de schema de Emmanuel todavía → verificación vía Jest + SQLite en memoria, no hay `curl` end-to-end contra Postgres real. Pendiente repetir los flujos 200/400/404/409 en vivo cuando esté disponible.
- `package-lock.json` sin diff (no se corrió `npm install`, solo se agregó una línea de script a mano).

Hallazgo fuera de alcance (no corregido, solo reportado): `GET /api/issuers/me` nunca quedó documentado en `documentacionAPI.md` desde el refactor de PR #94 — gap preexistente, no era parte de este ticket.