### PR TITLE
fix(frontend): static landing icons, centered signing rings, and stale wallet session recovery

### DIFF
--- a/frontend/src/components/FeatureBlocks.tsx
+++ b/frontend/src/components/FeatureBlocks.tsx
@@ -106,17 +106,11 @@ const FeatureBlocks = () => {
               variants={itemVariants}
               className="flex flex-col items-center text-center md:items-start md:text-left"
             >
-              <motion.div
+              <div
                 className={`clay-icon w-20 h-20 mb-8 bg-gradient-to-br ${feature.claySrc} ${feature.shadow}`}
-                animate={{ y: [0, -8, 0] }}
-                transition={{
-                  duration: 4 + (index % 3),
-                  repeat: Infinity,
-                  ease: 'easeInOut',
-                }}
               >
                 <img src={feature.imgSrc} alt={feature.alt} className="w-12 h-12 object-contain drop-shadow-[0_2px_8px_rgba(0,0,0,0.5)]" />
-              </motion.div>
+              </div>
 
               <h3 className="font-title text-2xl md:text-3xl font-black mb-4 text-white tracking-tight">
                 {feature.title}

--- a/frontend/src/components/ValueProposition.tsx
+++ b/frontend/src/components/ValueProposition.tsx
@@ -137,17 +137,11 @@ const ValueProposition = () => {
                   delay: index * 0.15,
                 }}
               >
-                <motion.div
+                <div
                   className={`clay-icon w-28 h-28 mb-8 bg-gradient-to-br ${step.claySrc} ${step.shadow}`}
-                  animate={{ y: [0, -10, 0] }}
-                  transition={{
-                    duration: 5 + index,
-                    repeat: Infinity,
-                    ease: 'easeInOut',
-                  }}
                 >
                   <img src={step.imgSrc} alt={step.alt} className="w-16 h-16 object-contain drop-shadow-[0_2px_8px_rgba(0,0,0,0.5)]" />
-                </motion.div>
+                </div>
 
                 <h3 className="font-title text-2xl md:text-3xl font-black mb-4 text-white tracking-tight">
                   {step.title}

--- a/frontend/src/components/auth/loginForm.tsx
+++ b/frontend/src/components/auth/loginForm.tsx
@@ -43,8 +43,8 @@ export const LoginForm = ({ disabled = false }: LoginFormProps) => {
     return (
       <div className="flex flex-col items-center justify-center py-8 space-y-6">
         <div className="relative">
-          <div className="absolute inset-0 -m-6 w-28 h-28 rounded-full border border-purple-500/30 animate-ping" />
-          <div className="absolute inset-0 -m-4 w-24 h-24 rounded-full border border-pink-500/20 animate-pulse" />
+          <div className="absolute -inset-4 rounded-full border border-purple-500/30 animate-ping" />
+          <div className="absolute -inset-2 rounded-full border border-pink-500/20 animate-pulse" />
 
           <div
             className="relative w-20 h-20 rounded-2xl flex items-center justify-center"

--- a/frontend/src/hooks/useWalletLogin.ts
+++ b/frontend/src/hooks/useWalletLogin.ts
@@ -53,13 +53,28 @@ export const useWalletLogin = () => {
             setPhase('awaiting-signature');
         };
 
+        // getAddress() and getProvider() can go out of sync — e.g. after
+        // navigating away and back within the SPA, AppKit may still report a
+        // cached address while the underlying provider connection has been
+        // dropped. Hydrating in that case would show a "Sign" button that
+        // fails with "Wallet provider unavailable". Only hydrate when both
+        // are present; otherwise drop the stale session so the user gets a
+        // working "Connect" button instead.
+        const hasLiveProvider = () => !!appKit.getProvider('eip155');
+
         const existing = appKit.getAddress();
-        if (existing) hydrate(existing);
+        if (existing) {
+            if (hasLiveProvider()) {
+                hydrate(existing);
+            } else {
+                appKit.disconnect().catch(() => { });
+            }
+        }
 
         // AppKit may restore the address asynchronously after the relay
         // reconnects. Subscribe so we hydrate as soon as it surfaces.
         const unsubscribe = appKit.subscribeAccount((account) => {
-            if (account.address) hydrate(account.address);
+            if (account.address && hasLiveProvider()) hydrate(account.address);
         });
 
         return () => { unsubscribe?.(); };

--- a/frontend/src/test/useWalletLogin.test.tsx
+++ b/frontend/src/test/useWalletLogin.test.tsx
@@ -311,6 +311,26 @@ describe('useWalletLogin — iOS reload hydration', () => {
         expect(result.current.walletAddress).toBe(MOCK_WALLET_LC);
         expect(result.current.isAwaitingSignature).toBe(true);
     });
+
+    it('drops a stale session instead of hydrating when the address exists but the provider does not', async () => {
+        // Reproduces the "Wallet provider unavailable" bug: the user connected,
+        // navigated away and back within the SPA. AppKit still reports the
+        // cached address, but the underlying provider connection was dropped.
+        vi.mocked(appKit.getAddress).mockReturnValue(MOCK_WALLET);
+        vi.mocked(appKit.getProvider).mockReturnValue(undefined as any);
+        vi.mocked(appKit.subscribeAccount).mockReturnValue(vi.fn());
+        vi.mocked(appKit.disconnect).mockResolvedValue(undefined);
+
+        const { result } = renderHook(() => useWalletLogin(), {
+            wrapper: createWrapper(),
+        });
+
+        await waitFor(() => {
+            expect(appKit.disconnect).toHaveBeenCalled();
+        });
+        expect(result.current.walletAddress).toBeNull();
+        expect(result.current.isAwaitingSignature).toBe(false);
+    });
 });
 
 describe('useWalletLogin — reset', () => {


### PR DESCRIPTION
Why

Three separate frontend issues reported during a visual pass over the app: (1) the icon cards under "Why Choose Us" and "How It Works" on the landing page bobbed up and down continuously — a common tell of AI-generated UI, distracting rather than polished; (2) the pulsing rings behind the wallet icon on the "Awaiting signature" screen were visibly off-center; (3) a wallet connected once, then navigating away from and back to the login screen within the SPA, would show a "Sign" button that failed with "Wallet provider unavailable" — the only recovery was manually disconnecting the wallet.

What

- FeatureBlocks.tsx / ValueProposition.tsx — removed the infinite animate={{ y: [...] }} loop on the feature/step icons. They keep their entrance animation (fade/slide in on scroll) but no longer bounce indefinitely once visible.
- loginForm.tsx — the two pulsing rings behind the wallet icon used inset-0 (anchors top-left) combined with a fixed w-*/h-* size and a negative margin, which expands the ring asymmetrically instead of centering it. Replaced with -inset-4 / -inset-2 (negative inset, no fixed size), which expands symmetrically on all four sides at the exact same final diameter (112×112 and 96×96).
- useWalletLogin.ts — root cause: AppKit's cached address (getAddress()) and its live provider connection (getProvider('eip155')) can go out of sync after SPA navigation — the address stays cached in localStorage, but the underlying connection is dropped. The mount-time hydration effect trusted the address alone and jumped straight to awaiting-signature, producing a broken "Sign" button. Now hydration requires both the address AND a live provider to be present; if the address exists without a live provider, the stale session is dropped via appKit.disconnect() so the user sees a working "Connect" button instead. The iOS Safari reload-recovery path this effect was built for is unaffected, since a real reconnect always has a live provider alongside the address.

Impact

Purely a frontend UX/correctness fix, no backend or API surface touched. No more manual disconnect needed to recover from the stale-session state. Landing page icons and the signing screen are now visually static/centered as intended.

Verification (local)

- npx tsc --noEmit: no errors in any of the touched files.
- useWalletLogin.test.tsx: 13/13 pass, including a new regression test for the stale-session case (address present, provider absent → session dropped, phase stays idle, Connect shown).
- Full frontend suite run before and after (via git stash comparison): the same pre-existing 21 failures across 5 unrelated files (registration.test.tsx and others) occur with or without this change — confirmed unrelated, not introduced here.
- Manually verified in-browser by the user: floating icons are now static, wallet signing rings are centered, and reconnecting after navigating away no longer throws "Wallet provider unavailable".
- Branch merged cleanly against upstream/main (through PR #95) with no conflicts — backend-only changes from #93/#94/#95 don't overlap with these frontend-only edits.