### PR TITLE
fix(certificates): use raw DROP NOT NULL in pending-state migration

### DIFF
--- a/backend/scripts/migrate-certificate-pending-state.js
+++ b/backend/scripts/migrate-certificate-pending-state.js
@@ -1,34 +1,28 @@
 require("dotenv").config({ path: require("path").join(__dirname, "../.env") });
 
 const { sequelize } = require("../models");
-const { DataTypes } = require("sequelize");
 
 // certificate_hash, token_id, and issue_date become nullable so a certificate
 // can be reserved (status: 'pending') before it has real chain data. The
 // existing unique index on certificate_hash is untouched — Postgres allows
 // multiple NULLs in a unique column, so several pending rows can coexist.
-// changeColumn is idempotent: re-running DROP NOT NULL on an already-nullable
-// column is a no-op in Postgres.
+//
+// Raw "DROP NOT NULL" only — deliberately not using Sequelize's changeColumn,
+// which always emits a full "ALTER COLUMN ... TYPE ..." even when the type
+// isn't changing. Production has a view (certificates_editable, not tracked
+// anywhere in this repo) that depends on these columns, and Postgres refuses
+// to alter a column's type while a view depends on it. Dropping NOT NULL
+// doesn't touch the column type, so it doesn't hit that restriction.
+// Idempotent: re-running DROP NOT NULL on an already-nullable column is a
+// no-op in Postgres.
 async function run() {
-  const q = sequelize.getQueryInterface();
-
-  await q.changeColumn("certificates", "certificate_hash", {
-    type: DataTypes.STRING(128),
-    unique: true,
-    allowNull: true,
-  });
+  await sequelize.query(`ALTER TABLE "certificates" ALTER COLUMN "certificate_hash" DROP NOT NULL`);
   console.log("certificate_hash is now nullable");
 
-  await q.changeColumn("certificates", "token_id", {
-    type: DataTypes.STRING(78),
-    allowNull: true,
-  });
+  await sequelize.query(`ALTER TABLE "certificates" ALTER COLUMN "token_id" DROP NOT NULL`);
   console.log("token_id is now nullable");
 
-  await q.changeColumn("certificates", "issue_date", {
-    type: DataTypes.DATEONLY,
-    allowNull: true,
-  });
+  await sequelize.query(`ALTER TABLE "certificates" ALTER COLUMN "issue_date" DROP NOT NULL`);
   console.log("issue_date is now nullable");
 
   await sequelize.close();


### PR DESCRIPTION
## Summary
- `backend/scripts/migrate-certificate-pending-state.js` (introduced in #97) failed against the real database with `cannot alter type of a column used by a view or rule` — production has a view, `certificates_editable`, depending on `certificates.certificate_hash` that isn't tracked anywhere in this repo.
- Root cause: Sequelize's `changeColumn` always emits a full `ALTER COLUMN ... TYPE ...`, even when the type doesn't actually change, and Postgres refuses that while a view depends on the column.
- Fix: replaced `changeColumn` with raw `ALTER TABLE ... DROP NOT NULL` statements, which don't touch column type and so don't hit the view dependency restriction. Still idempotent — re-running on an already-nullable column is a no-op in Postgres.
- This landed after #97 was already merged, so it needs its own PR to reach `main`.

## Test plan
- [x] Re-ran `npm run migrate:certificate-pending-state` against the real database — completes successfully now
- [x] `npx jest certificates` — 8/8 suites, 45/45 tests pass (unaffected by this change, confirms nothing else broke)