### PR TITLE
fix(frontend): claim flowOwnedRef during signAndLogin to stop UI reset mid-signature

### DIFF
--- a/frontend/src/hooks/useWalletLogin.ts
+++ b/frontend/src/hooks/useWalletLogin.ts
@@ -97,6 +97,7 @@ export const useWalletLogin = () => {
                 signature,
             }),
         onSuccess: (data) => {
+            flowOwnedRef.current = false;
             login({
                 id: data.user.id,
                 email: data.user.email ?? '',
@@ -112,6 +113,7 @@ export const useWalletLogin = () => {
             else navigate('/');
         },
         onError: (err: Error) => {
+            flowOwnedRef.current = false;
             const notFound = err instanceof ApiServiceError && err.status === 404;
             safeSet(setIsWalletNotFound, notFound);
             safeSet(setError, err.message);
@@ -201,6 +203,14 @@ export const useWalletLogin = () => {
         setError(null);
         setIsWalletNotFound(false);
         setPhase('signing');
+        // Claim ownership of the state machine for the whole flow — nonce
+        // fetch, the wallet's signature prompt (which can stay open for a
+        // while waiting on the user), and the login request. Without this,
+        // the mount-level hydrate listener below can fire mid-flow (AppKit
+        // re-emits account events while the signature prompt is open) and
+        // stomp phase back to 'awaiting-signature' while the prompt is still
+        // legitimately open, making the page look like it silently reset.
+        flowOwnedRef.current = true;
 
         try {
             const walletProvider = appKit.getProvider('eip155');
@@ -218,6 +228,7 @@ export const useWalletLogin = () => {
 
             mutation.mutate({ walletAddress, signature });
         } catch (err: unknown) {
+            flowOwnedRef.current = false;
             safeSet(setError, err instanceof Error ? err.message : 'Failed to sign message');
             safeSet(setPhase, 'awaiting-signature');
         }


### PR DESCRIPTION
## Summary
- Reported symptom: after clicking "Sign to log in", the sign-in screen would silently revert to "Wallet connected / Sign to log in" 2-5 seconds later, even while MetaMask's own signature popup was still open and legitimately waiting on the user. Login still worked if you went back and confirmed the still-open popup — this was a purely visual/state bug, not an auth failure.
- Root cause: `flowOwnedRef` in `useWalletLogin.ts` is documented (see its own comment) to track an active `connect()` **or** `signAndLogin()`, so the mount-level AppKit account-hydration listener knows to stay out of the way while a flow is in progress. In practice, only `connect()` ever set it — `signAndLogin()` never did. So while the wallet's signature prompt was open (blocking on `signer.signMessage()` for however long the user takes), any AppKit account-event re-emission during that window would let the hydration listener stomp `phase` back to `'awaiting-signature'`, snapping the UI back even though nothing had actually failed.
- Fix: `signAndLogin` now claims `flowOwnedRef.current = true` right after entering the `'signing'` phase, and releases it in the local catch block plus both `mutation.onSuccess` and `mutation.onError` — mirroring the guard `connect()` already had.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/test/useWalletLogin.test.tsx` — 13/13 pass
- [ ] Manual re-test in the browser: click "Sign to log in", let the MetaMask popup sit open for several seconds before confirming — the sign-in screen should stay on the signing/loading state instead of reverting