### PR TITLE
fix(certificates): look up share endpoint by NFT token_id, not intern…

### DIFF
--- a/backend/documentacionAPI.md
+++ b/backend/documentacionAPI.md
@@ -633,7 +633,7 @@ no es público.
 
 | Parámetro | Tipo | Descripción |
 |---|---|---|
-| `id` | `number` | ID del certificado en la base de datos |
+| `id` | `string` | `token_id` del NFT (el campo `identifier` que devuelve `POST /api/opensea/certificates/`) — **no** el `Certificate.id` interno de la base de datos, que el frontend nunca recibe |
 
 **Autenticación**: Requerida — Bearer token o cookie de sesión; la wallet autenticada debe
 coincidir (case-insensitive) con `student_wallet_address` del certificado.

--- a/backend/routes/certificates.js
+++ b/backend/routes/certificates.js
@@ -586,11 +586,15 @@ router.get("/database/:id", async (req, res) => {
 });
 
 // POST /api/certificates/:id/share
+// `:id` is the NFT token_id (OpenSea's `identifier`), not the DB primary key —
+// the talent dashboard only ever has the OpenSea-shaped certificate object
+// (from POST /api/opensea/certificates/), which has no way to know our
+// internal Certificate.id.
 router.post("/:id/share", authenticate, async (req, res) => {
   try {
     const { id } = req.params;
 
-    const certificate = await Certificate.findByPk(id);
+    const certificate = await Certificate.findOne({ where: { token_id: String(id) } });
     if (!certificate) {
       return res.status(404).json({ error: "Certificate not found" });
     }

--- a/backend/tests/certificates.test.js
+++ b/backend/tests/certificates.test.js
@@ -205,11 +205,11 @@ describe("POST /api/certificates/:id/share", () => {
       student_wallet_address: studentWallet,
       title: "Test Certificate",
       certificate_hash: crypto.randomBytes(16).toString("hex"),
-      token_id: "1",
+      token_id: "42",
       issue_date: "2026-01-01",
     });
 
-    return { certificateId: certificate.id, issuerWallet, studentWallet };
+    return { certificateId: certificate.id, tokenId: certificate.token_id, issuerWallet, studentWallet };
   };
 
   const issueSession = async (wallet, role) => {
@@ -283,11 +283,11 @@ describe("POST /api/certificates/:id/share", () => {
   });
 
   test("403 when the authenticated wallet does not own the certificate", async () => {
-    const { certificateId } = await seedCertificate();
+    const { tokenId } = await seedCertificate();
     const token = await issueSession(makeWallet(), "student");
 
     const res = await request(app)
-      .post(`/api/certificates/${certificateId}/share`)
+      .post(`/api/certificates/${tokenId}/share`)
       .set("Authorization", `Bearer ${token}`)
       .expect(403);
 
@@ -295,21 +295,21 @@ describe("POST /api/certificates/:id/share", () => {
   });
 
   test("401 without a session", async () => {
-    const { certificateId } = await seedCertificate();
+    const { tokenId } = await seedCertificate();
 
     const res = await request(app)
-      .post(`/api/certificates/${certificateId}/share`)
+      .post(`/api/certificates/${tokenId}/share`)
       .expect(401);
 
     expect(res.body).toHaveProperty("error");
   });
 
   test("200 when the certificate's own student shares it, incrementing share_count", async () => {
-    const { certificateId, studentWallet } = await seedCertificate();
+    const { tokenId, studentWallet } = await seedCertificate();
     const token = await issueSession(studentWallet, "student");
 
     const res = await request(app)
-      .post(`/api/certificates/${certificateId}/share`)
+      .post(`/api/certificates/${tokenId}/share`)
       .set("Authorization", `Bearer ${token}`)
       .expect(200);
 
@@ -321,6 +321,22 @@ describe("POST /api/certificates/:id/share", () => {
 
     const res = await request(app)
       .post("/api/certificates/999999/share")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404);
+
+    expect(res.body).toHaveProperty("error");
+  });
+
+  test("404 when :id matches the DB primary key but not the token_id", async () => {
+    // Locks in the intended contract change: :id is the NFT token_id, so a
+    // caller sending the internal Certificate.id (which the frontend never
+    // has access to) must not accidentally match.
+    const { certificateId, tokenId, studentWallet } = await seedCertificate();
+    expect(String(certificateId)).not.toEqual(tokenId);
+    const token = await issueSession(studentWallet, "student");
+
+    const res = await request(app)
+      .post(`/api/certificates/${certificateId}/share`)
       .set("Authorization", `Bearer ${token}`)
       .expect(404);
 


### PR DESCRIPTION
…al PK

Why: the talent dashboard only receives OpenSea-shaped certificate data (POST /api/opensea/certificates/), which has no internal Certificate.id, so every share attempt failed with 403.
What: POST /api/certificates/:id/share now resolves the certificate by token_id instead of findByPk, keeping the same ownership check; docs and tests updated to match, including a regression test that locks out the old PK-based lookup.
Impact: talents can share their certificates from the dashboard using the identifier they actually have; no change for other certificate endpoints.