### PR TITLE
feat(backend): add profile columns to Student

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ npm run migrate:referrals-phase1      # adds referrals, incentives_pool_ledger t
 npm run migrate:issuer-share-count    # adds share_count column to issuers
 npm run migrate:certificate-share-count  # adds share_count column to certificates
 npm run migrate:issuer-certificate-logo  # adds certificate_logo_url column to issuers
+npm run migrate:student-profile       # adds photo_url, bio, knowledge_areas, social links, share_count to students
 ```
 
 Each script is idempotent — safe to run more than once.

--- a/backend/models/students.js
+++ b/backend/models/students.js
@@ -17,6 +17,40 @@ module.exports = (sequelize, DataTypes) => {
     field_of_study: {
       type: DataTypes.STRING(255),
       allowNull: true
+    },
+    photo_url: {
+      type: DataTypes.STRING(500),
+      allowNull: true
+    },
+    bio: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    knowledge_areas: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      defaultValue: []
+    },
+    github_url: {
+      type: DataTypes.STRING(500),
+      allowNull: true
+    },
+    linkedin_url: {
+      type: DataTypes.STRING(500),
+      allowNull: true
+    },
+    twitter_url: {
+      type: DataTypes.STRING(500),
+      allowNull: true
+    },
+    instagram_url: {
+      type: DataTypes.STRING(500),
+      allowNull: true
+    },
+    share_count: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0
     }
   }, {
     tableName: 'students',

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "migrate:issuer-share-count": "node scripts/migrate-issuer-share-count.js",
     "migrate:certificate-share-count": "node scripts/migrate-certificate-share-count.js",
     "migrate:issuer-certificate-logo": "node scripts/migrate-issuer-certificate-logo.js",
+    "migrate:student-profile": "node scripts/migrate-student-profile.js",
     "migrate:certificate-pending-state": "node scripts/migrate-certificate-pending-state.js",
     "migrate:harjoot-phase1": "node scripts/migrate-harjoot-phase1.js",
     "migrate:referrals-phase1": "node scripts/migrate-referrals-phase1.js"

--- a/backend/scripts/migrate-student-profile.js
+++ b/backend/scripts/migrate-student-profile.js
@@ -1,0 +1,46 @@
+require("dotenv").config({ path: require("path").join(__dirname, "../.env") });
+
+const { sequelize } = require("../models");
+const { DataTypes } = require("sequelize");
+
+async function run() {
+  const q = sequelize.getQueryInterface();
+  const columns = await q.describeTable("students");
+
+  const toAdd = [
+    { name: "photo_url", missing: !columns.photo_url, def: { type: DataTypes.STRING(500), allowNull: true } },
+    { name: "bio", missing: !columns.bio, def: { type: DataTypes.TEXT, allowNull: true } },
+    {
+      name: "knowledge_areas",
+      missing: !columns.knowledge_areas,
+      def: { type: DataTypes.JSONB, allowNull: true, defaultValue: [] },
+    },
+    { name: "github_url", missing: !columns.github_url, def: { type: DataTypes.STRING(500), allowNull: true } },
+    { name: "linkedin_url", missing: !columns.linkedin_url, def: { type: DataTypes.STRING(500), allowNull: true } },
+    { name: "twitter_url", missing: !columns.twitter_url, def: { type: DataTypes.STRING(500), allowNull: true } },
+    { name: "instagram_url", missing: !columns.instagram_url, def: { type: DataTypes.STRING(500), allowNull: true } },
+    {
+      name: "share_count",
+      missing: !columns.share_count,
+      // defaultValue backfills existing rows so the NOT NULL add succeeds.
+      def: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    },
+  ];
+
+  for (const col of toAdd) {
+    if (col.missing) {
+      await q.addColumn("students", col.name, col.def);
+      console.log(`Added column: ${col.name}`);
+    } else {
+      console.log(`Column already exists: ${col.name}`);
+    }
+  }
+
+  await sequelize.close();
+  console.log("Migration complete.");
+}
+
+run().catch((err) => {
+  console.error("Migration failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

El talento no tiene perfil. El modelo `Student` solo guarda `field_of_study`, mientras que el educador ya tiene `photo_url`, `bio`, `knowledge_areas`, redes y `share_count`.

Sin estas columnas no se puede construir ni el perfil público ni la edición propia, y además **bloquea el trabajo de @Fernando Anastasia** (`updateStudentPhoto`, `registerStudentProfileShare`). Por eso va en un PR chico y separado, antes del resto de mis tareas del ticket.

## What

- **`backend/scripts/migrate-student-profile.js`** (nuevo): agrega a `students` las 8 columnas del ticket — `photo_url`, `bio`, `knowledge_areas` (JSONB), `github_url`, `linkedin_url`, `twitter_url`, `instagram_url` y `share_count`. Idempotente, mismo patrón que `migrate-issuer-social-links.js` (`describeTable` + `addColumn` solo si falta).
- **`backend/models/students.js`**: las mismas 8 columnas, con tipos idénticos a los de la migración.
- **`backend/package.json`**: script `migrate:student-profile`.
- **`README.md`**: la migración registrada en la lista.

Nota: `github_url` e `instagram_url` no existen en `Issuer` (que tiene `website_url`), son nuevas para talento.

## Impact

Aditivo. Todas las columnas son nullable salvo `share_count`, que entra `NOT NULL` con `defaultValue: 0` — el default backfillea las filas existentes para que el `NOT NULL` no falle. Ningún endpoint las lee todavía, así que **ninguna respuesta actual cambia**.

⚠️ **Hay que correr la migración en el deploy**: `npm run migrate:student-profile`, con el endpoint directo/unpooled (PgBouncer en transaction mode rechaza DDL).

## Verification (local)

Contra Postgres en Docker, nunca contra la Neon de producción:

- `node scripts/migrate-student-profile.js` → las 8 columnas creadas ("Added column: ..." ×8).
- Segunda corrida → "Column already exists: ..." ×8, idempotencia confirmada.
- `\d students` verifica los tipos: `knowledge_areas` es `jsonb` con default `'[]'::jsonb`, `share_count` es `integer NOT NULL DEFAULT 0`, las URLs `varchar(500)` y `bio` `text`.
- Suite completa: **994/1001**. Los 7 fallos son los preexistentes de siempre (`referralModels` ×5, `register`, `precheckCertificate`), iguales en `main` y ajenos a este cambio.
- `package-lock.json` sin diff (este PR no toca dependencias).
