### PR TITLE
feat(backend): talent public/own profile endpoints

### DIFF
--- a/backend/documentacionAPI.md
+++ b/backend/documentacionAPI.md
@@ -1755,6 +1755,10 @@ objeto `user` completo del talento.
 }
 ```
 
+> `total_certificates` cuenta **solo los certificados emitidos y no revocados** (`status: "issued"`
+> e `is_revoked: false`). Los revocados y los que siguen reservados sin mintear (`status: "pending"`)
+> quedan fuera, para que el número sea confiable en un endpoint público.
+
 ---
 
 ### GET `/api/students/me`

--- a/backend/documentacionAPI.md
+++ b/backend/documentacionAPI.md
@@ -1710,6 +1710,146 @@ Obtiene el detalle de un estudiante específico por su wallet address, incluyend
 
 ---
 
+### GET `/api/students/:wallet_address/public`
+
+Perfil **público** del talento. **No requiere autenticación** y **nunca expone el email**.
+
+No confundir con `GET /api/students/:wallet_address`, que sí requiere autenticación y devuelve el
+objeto `user` completo del talento.
+
+**Parámetros de ruta**
+
+| Parámetro | Tipo | Descripción |
+|---|---|---|
+| `wallet_address` | `string` | Wallet address del talento (se normaliza a minúsculas) |
+
+**Respuestas**
+
+| Código | Descripción |
+|---|---|
+| `200` | Perfil público del talento |
+| `400` | `Invalid wallet address` — wallet mal formada |
+| `404` | `Student not found` |
+| `500` | Error al obtener el perfil |
+
+**Ejemplo de respuesta exitosa**
+
+```json
+{
+  "student": {
+    "wallet_address": "0x...",
+    "name": "Ana",
+    "lastname": "Pérez",
+    "field_of_study": "Ciberseguridad",
+    "photo_url": "ipfs://Qm...",
+    "bio": "Talento en formación",
+    "knowledge_areas": ["Rust", "Penetration Testing"],
+    "github_url": "https://github.com/ana",
+    "linkedin_url": null,
+    "twitter_url": null,
+    "instagram_url": null,
+    "share_count": 4,
+    "total_certificates": 2,
+    "joined_at": "2025-01-10T08:00:00.000Z"
+  }
+}
+```
+
+---
+
+### GET `/api/students/me`
+
+Perfil completo del talento autenticado. **Sí incluye el email** (solo lectura).
+
+**Autenticación:** requerida. Solo cuentas con rol `student`.
+
+**Respuestas**
+
+| Código | Descripción |
+|---|---|
+| `200` | Perfil propio del talento |
+| `403` | `Only talent accounts can access this endpoint` |
+| `404` | `Student not found` |
+| `500` | Error al obtener el perfil |
+
+**Ejemplo de respuesta exitosa**
+
+```json
+{
+  "wallet_address": "0x...",
+  "field_of_study": "Ciberseguridad",
+  "photo_url": null,
+  "bio": null,
+  "knowledge_areas": [],
+  "github_url": null,
+  "linkedin_url": null,
+  "twitter_url": null,
+  "instagram_url": null,
+  "share_count": 2,
+  "name": "Ana",
+  "lastname": "Pérez",
+  "email": "ana@ejemplo.com",
+  "email_verified": true
+}
+```
+
+> `name`, `lastname`, `email` y `email_verified` viven en la tabla `users` y son **de solo lectura**
+> acá: `PATCH /me` no los modifica. Cambiar el email requiere su propio flujo de reverificación.
+
+---
+
+### PATCH `/api/students/me`
+
+Actualiza el perfil del talento autenticado. Actualización **parcial**: solo se modifican los campos
+presentes en el body.
+
+**Autenticación:** requerida. Solo cuentas con rol `student`.
+
+**Body** (todos opcionales)
+
+| Campo | Tipo | Descripción |
+|---|---|---|
+| `bio` | `string \| null` | Máximo 500 caracteres. Se le aplica `trim` |
+| `knowledge_areas` | `string[]` | Máximo 5 elementos, cada uno string de máximo 100 caracteres |
+| `field_of_study` | `string \| null` | Máximo 255 caracteres. Se le aplica `trim` |
+| `github_url` | `string \| null` | URL `https://` de máximo 500 caracteres. `null` borra el link |
+| `linkedin_url` | `string \| null` | Ídem |
+| `twitter_url` | `string \| null` | Ídem |
+| `instagram_url` | `string \| null` | Ídem |
+
+La foto (`photo_url`) **no** se actualiza por acá — tiene su propio endpoint.
+
+**Respuestas**
+
+| Código | Descripción |
+|---|---|
+| `200` | Perfil actualizado |
+| `400` | Validación fallida (`bio must be 500 characters or less`, `Maximum 5 knowledge areas allowed`, `github_url must be a valid https:// URL`, etc.) |
+| `403` | `Only talent accounts can update this profile` |
+| `404` | `Student not found` |
+| `500` | Error al actualizar |
+
+**Ejemplo de respuesta exitosa**
+
+```json
+{
+  "message": "Profile updated",
+  "student": {
+    "wallet_address": "0x...",
+    "field_of_study": "Ingeniería",
+    "photo_url": null,
+    "bio": "Talento en formación",
+    "knowledge_areas": ["Rust", "Penetration Testing"],
+    "github_url": "https://github.com/ana",
+    "linkedin_url": null,
+    "twitter_url": null,
+    "instagram_url": null
+  }
+}
+```
+
+---
+
 ### PUT `/api/students/:wallet_address`
 
 Actualiza el campo de estudio de un estudiante.

--- a/backend/routes/students.js
+++ b/backend/routes/students.js
@@ -4,6 +4,68 @@ const router = express.Router();
 const { Student, User, Certificate, Issuer } = require("../models");
 const { authenticate } = require("../middleware/auth");
 const { validateDeletionMessage, deleteStudentAccount } = require("../services/studentService");
+const { getPublicStudentProfile } = require("../usecases/students/getPublicStudentProfile");
+const { getOwnStudentProfile } = require("../usecases/students/getOwnStudentProfile");
+const { updateOwnStudentProfile } = require("../usecases/students/updateOwnStudentProfile");
+
+// GET /api/students/me — own full profile (authenticated).
+// Must be registered before /:wallet_address to avoid param capture.
+router.get("/me", authenticate, async (req, res) => {
+  if (req.auth.role !== "student") {
+    return res.status(403).json({ error: "Only talent accounts can access this endpoint" });
+  }
+
+  try {
+    const result = await getOwnStudentProfile({ models: { Student, User }, wallet: req.auth.wallet });
+    if (!result.ok) return res.status(result.httpStatus).json({ error: result.message });
+    return res.json(result.data);
+  } catch (err) {
+    console.error("GET /api/students/me error:", err);
+    return res.status(500).json({ error: "Failed to fetch profile" });
+  }
+});
+
+// PATCH /api/students/me — update own profile.
+// Must be registered before /:wallet_address to avoid param capture.
+router.patch("/me", authenticate, async (req, res) => {
+  if (req.auth.role !== "student") {
+    return res.status(403).json({ error: "Only talent accounts can update this profile" });
+  }
+
+  try {
+    const result = await updateOwnStudentProfile({
+      models: { Student },
+      wallet: req.auth.wallet,
+      bio: req.body.bio,
+      knowledgeAreas: req.body.knowledge_areas,
+      fieldOfStudy: req.body.field_of_study,
+      githubUrl: req.body.github_url,
+      linkedinUrl: req.body.linkedin_url,
+      twitterUrl: req.body.twitter_url,
+      instagramUrl: req.body.instagram_url,
+    });
+    if (!result.ok) return res.status(result.httpStatus).json({ error: result.message });
+    return res.json(result.data);
+  } catch (err) {
+    console.error("PATCH /api/students/me error:", err);
+    return res.status(500).json({ error: "Failed to update profile" });
+  }
+});
+
+// GET /api/students/:wallet_address/public — public profile (no auth, no email exposed)
+router.get("/:wallet_address/public", async (req, res) => {
+  try {
+    const result = await getPublicStudentProfile({
+      models: { Student, User, Certificate },
+      walletAddress: req.params.wallet_address,
+    });
+    if (!result.ok) return res.status(result.httpStatus).json({ error: result.message });
+    return res.json(result.data);
+  } catch (err) {
+    console.error("GET /api/students/:wallet_address/public error:", err);
+    return res.status(500).json({ error: "Failed to fetch student profile" });
+  }
+});
 
 // GET /api/students
 router.get("/", authenticate, async (req, res) => {

--- a/backend/tests/students-profile.test.js
+++ b/backend/tests/students-profile.test.js
@@ -1,0 +1,211 @@
+// Covers the HTTP contract of the talent profile endpoints:
+//   GET   /api/students/me
+//   PATCH /api/students/me
+//   GET   /api/students/:wallet_address/public
+const request = require("supertest");
+const express = require("express");
+const bodyParser = require("body-parser");
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+
+jest.setTimeout(20000);
+
+jest.mock("../services/redis", () => ({
+  cacheSession: jest.fn().mockResolvedValue(undefined),
+  deleteSession: jest.fn().mockResolvedValue(undefined),
+  sessionExists: jest.fn().mockResolvedValue(false),
+}));
+jest.mock("express-rate-limit", () => () => (req, res, next) => next());
+jest.mock("../services/studentService", () => ({
+  validateDeletionMessage: jest.fn(),
+  deleteStudentAccount: jest.fn(),
+}));
+
+describe("Student profile routes", () => {
+  let sequelize;
+  let User, Issuer, Student, Recruiter, Certificate, UserSession;
+  let app;
+
+  const STUDENT = "0x" + "aa".repeat(20);
+  const ISSUER = "0x" + "bb".repeat(20);
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    await sequelize.query("PRAGMA foreign_keys = OFF");
+
+    const { DataTypes } = SequelizePkg;
+    User = require("../models/users")(sequelize, DataTypes);
+    Issuer = require("../models/issuers")(sequelize, DataTypes);
+    Student = require("../models/students")(sequelize, DataTypes);
+    // SQLite requires UNIQUE on any column referenced by a FK; the production
+    // Student model doesn't declare it (Postgres is more permissive).
+    Student.rawAttributes.wallet_address.unique = true;
+    Recruiter = require("../models/recruiters")(sequelize, DataTypes);
+    Certificate = require("../models/certificates")(sequelize, DataTypes);
+    UserSession = require("../models/userSessions")(sequelize, DataTypes);
+
+    const modelsMock = { User, Issuer, Student, Recruiter, Certificate, UserSession, sequelize, Sequelize: SequelizePkg };
+    Object.values(modelsMock).forEach((m) => m?.associate?.(modelsMock));
+
+    await sequelize.sync({ force: true });
+
+    jest.isolateModules(() => {
+      jest.doMock("../models", () => modelsMock);
+      jest.doMock("../middleware/auth", () => ({
+        authenticate: (req, res, next) => {
+          req.auth = {
+            wallet: req.headers["x-test-wallet"] || STUDENT,
+            role: req.headers["x-test-role"] || "student",
+          };
+          next();
+        },
+      }));
+
+      const studentsRoute = require("../routes/students");
+      app = express();
+      app.use(bodyParser.json());
+      app.use("/api/students", studentsRoute);
+    });
+  });
+
+  afterAll(async () => {
+    jest.resetModules();
+    if (sequelize) await sequelize.close();
+  });
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    await sequelize.sync({ force: true });
+
+    const nonce = () => crypto.randomBytes(16).toString("hex");
+    await User.create({
+      wallet_address: STUDENT,
+      role: "student",
+      name: "Ana",
+      lastname: "Perez",
+      email: "ana@example.com",
+      email_verified: true,
+      nonce: nonce(),
+    });
+    await Student.create({ wallet_address: STUDENT, field_of_study: "Ciberseguridad", share_count: 2 });
+
+    await User.create({ wallet_address: ISSUER, role: "issuer", name: "Prof", nonce: nonce() });
+    await Issuer.create({ wallet_address: ISSUER, organization_name: "HackAcademy" });
+    await Certificate.create({
+      issuer_wallet_address: ISSUER,
+      student_wallet_address: STUDENT,
+      title: "A",
+      certificate_hash: "h1",
+      token_id: "1",
+      issue_date: "2026-01-01",
+    });
+  });
+
+  describe("GET /api/students/me", () => {
+    test("200 with the full own profile including email", async () => {
+      const res = await request(app).get("/api/students/me").expect(200);
+      expect(res.body).toEqual({
+        wallet_address: STUDENT,
+        field_of_study: "Ciberseguridad",
+        photo_url: null,
+        bio: null,
+        knowledge_areas: [],
+        github_url: null,
+        linkedin_url: null,
+        twitter_url: null,
+        instagram_url: null,
+        share_count: 2,
+        name: "Ana",
+        lastname: "Perez",
+        email: "ana@example.com",
+        email_verified: true,
+      });
+    });
+
+    test("403 for a non-student role", async () => {
+      const res = await request(app).get("/api/students/me").set("x-test-role", "issuer").expect(403);
+      expect(res.body).toEqual({ error: "Only talent accounts can access this endpoint" });
+    });
+
+    test("404 when the authenticated wallet has no student row", async () => {
+      const res = await request(app).get("/api/students/me").set("x-test-wallet", "0x" + "ff".repeat(20)).expect(404);
+      expect(res.body).toEqual({ error: "Student not found" });
+    });
+
+    test("is not captured by GET /:wallet_address", async () => {
+      const res = await request(app).get("/api/students/me").expect(200);
+      expect(res.body).not.toHaveProperty("student");
+    });
+  });
+
+  describe("PATCH /api/students/me", () => {
+    test("200 and persists the update", async () => {
+      const res = await request(app)
+        .patch("/api/students/me")
+        .send({ bio: "Talento en formacion", knowledge_areas: ["Rust"], github_url: "https://github.com/ana" })
+        .expect(200);
+
+      expect(res.body.message).toBe("Profile updated");
+      expect(res.body.student.bio).toBe("Talento en formacion");
+
+      const stored = await Student.findOne({ where: { wallet_address: STUDENT } });
+      expect(stored.github_url).toBe("https://github.com/ana");
+    });
+
+    test("400 for a bio over 500 characters", async () => {
+      const res = await request(app).patch("/api/students/me").send({ bio: "x".repeat(501) }).expect(400);
+      expect(res.body).toEqual({ error: "bio must be 500 characters or less" });
+    });
+
+    test("400 for more than 5 knowledge areas", async () => {
+      const res = await request(app)
+        .patch("/api/students/me")
+        .send({ knowledge_areas: ["a", "b", "c", "d", "e", "f"] })
+        .expect(400);
+      expect(res.body).toEqual({ error: "Maximum 5 knowledge areas allowed" });
+    });
+
+    test("400 for a non-https social link", async () => {
+      const res = await request(app).patch("/api/students/me").send({ linkedin_url: "ftp://x" }).expect(400);
+      expect(res.body).toEqual({ error: "linkedin_url must be a valid https:// URL" });
+    });
+
+    test("403 for a non-student role", async () => {
+      const res = await request(app).patch("/api/students/me").set("x-test-role", "recruiter").send({ bio: "x" }).expect(403);
+      expect(res.body).toEqual({ error: "Only talent accounts can update this profile" });
+    });
+
+    test("ignores User-owned fields sent in the body", async () => {
+      await request(app).patch("/api/students/me").send({ bio: "ok", email: "evil@example.com", name: "Hacker" }).expect(200);
+
+      const user = await User.findOne({ where: { wallet_address: STUDENT } });
+      expect(user.email).toBe("ana@example.com");
+      expect(user.name).toBe("Ana");
+    });
+  });
+
+  describe("GET /api/students/:wallet_address/public", () => {
+    test("200 with the public profile and no email anywhere in the response", async () => {
+      const res = await request(app).get(`/api/students/${STUDENT}/public`).expect(200);
+
+      expect(res.body.student.wallet_address).toBe(STUDENT);
+      expect(res.body.student.total_certificates).toBe(1);
+      expect(res.body.student.share_count).toBe(2);
+      expect(res.body.student).not.toHaveProperty("email");
+      expect(JSON.stringify(res.body)).not.toContain("ana@example.com");
+    });
+
+    test("400 for a malformed wallet", async () => {
+      const res = await request(app).get("/api/students/not-a-wallet/public").expect(400);
+      expect(res.body).toEqual({ error: "Invalid wallet address" });
+    });
+
+    test("404 for an unknown wallet", async () => {
+      const res = await request(app).get(`/api/students/0x${"ff".repeat(20)}/public`).expect(404);
+      expect(res.body).toEqual({ error: "Student not found" });
+    });
+  });
+});

--- a/backend/tests/students-profile.test.js
+++ b/backend/tests/students-profile.test.js
@@ -198,6 +198,27 @@ describe("Student profile routes", () => {
       expect(JSON.stringify(res.body)).not.toContain("ana@example.com");
     });
 
+    test("total_certificates skips revoked and still-pending certificates", async () => {
+      await Certificate.create({
+        issuer_wallet_address: ISSUER,
+        student_wallet_address: STUDENT,
+        title: "Revocado",
+        certificate_hash: "h2",
+        token_id: "2",
+        issue_date: "2026-01-01",
+        is_revoked: true,
+      });
+      await Certificate.create({
+        issuer_wallet_address: ISSUER,
+        student_wallet_address: STUDENT,
+        title: "Reservado",
+        status: "pending",
+      });
+
+      const res = await request(app).get(`/api/students/${STUDENT}/public`).expect(200);
+      expect(res.body.student.total_certificates).toBe(1);
+    });
+
     test("400 for a malformed wallet", async () => {
       const res = await request(app).get("/api/students/not-a-wallet/public").expect(400);
       expect(res.body).toEqual({ error: "Invalid wallet address" });

--- a/backend/usecases/students/__tests__/getOwnStudentProfile.test.js
+++ b/backend/usecases/students/__tests__/getOwnStudentProfile.test.js
@@ -1,0 +1,84 @@
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+const { getOwnStudentProfile } = require("../getOwnStudentProfile");
+
+jest.setTimeout(15000);
+
+const STUDENT = "0x" + "aa".repeat(20);
+
+describe("getOwnStudentProfile", () => {
+  let sequelize, models;
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    await sequelize.query("PRAGMA foreign_keys = OFF");
+
+    const { DataTypes } = SequelizePkg;
+    const User = require("../../../models/users")(sequelize, DataTypes);
+    const Issuer = require("../../../models/issuers")(sequelize, DataTypes);
+    const Student = require("../../../models/students")(sequelize, DataTypes);
+    // SQLite requires UNIQUE on any column referenced by a FK; the production
+    // Student model doesn't declare it (Postgres is more permissive).
+    Student.rawAttributes.wallet_address.unique = true;
+    const Recruiter = require("../../../models/recruiters")(sequelize, DataTypes);
+    const Certificate = require("../../../models/certificates")(sequelize, DataTypes);
+    const UserSession = require("../../../models/userSessions")(sequelize, DataTypes);
+
+    models = { User, Issuer, Student, Recruiter, Certificate, UserSession, sequelize, Sequelize: SequelizePkg };
+    Object.values(models).forEach((m) => m?.associate && m.associate(models));
+    await sequelize.sync({ force: true });
+
+    await models.User.create({
+      wallet_address: STUDENT,
+      role: "student",
+      name: "Ana",
+      lastname: "Perez",
+      email: "ana@example.com",
+      email_verified: true,
+      nonce: crypto.randomBytes(16).toString("hex"),
+    });
+    await models.Student.create({ wallet_address: STUDENT, field_of_study: "Ciberseguridad" });
+  });
+
+  afterAll(() => sequelize.close());
+
+  test("throws TypeError when models or wallet is missing", async () => {
+    await expect(getOwnStudentProfile({ wallet: STUDENT })).rejects.toThrow(TypeError);
+  });
+
+  test("returns STUDENT_NOT_FOUND for an unknown wallet", async () => {
+    const result = await getOwnStudentProfile({ models, wallet: "0x" + "ff".repeat(20) });
+    expect(result.code).toBe("STUDENT_NOT_FOUND");
+    expect(result.httpStatus).toBe(404);
+  });
+
+  test("returns the full own profile including email", async () => {
+    const result = await getOwnStudentProfile({ models, wallet: STUDENT });
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({
+      wallet_address: STUDENT,
+      field_of_study: "Ciberseguridad",
+      photo_url: null,
+      bio: null,
+      knowledge_areas: [],
+      github_url: null,
+      linkedin_url: null,
+      twitter_url: null,
+      instagram_url: null,
+      share_count: 0,
+      name: "Ana",
+      lastname: "Perez",
+      email: "ana@example.com",
+      email_verified: true,
+    });
+  });
+
+  test("accepts an uppercase wallet and normalizes it", async () => {
+    const result = await getOwnStudentProfile({ models, wallet: STUDENT.toUpperCase().replace("0X", "0x") });
+    expect(result.ok).toBe(true);
+    expect(result.data.wallet_address).toBe(STUDENT);
+  });
+});

--- a/backend/usecases/students/__tests__/getPublicStudentProfile.test.js
+++ b/backend/usecases/students/__tests__/getPublicStudentProfile.test.js
@@ -59,6 +59,9 @@ describe("getPublicStudentProfile", () => {
     const issueDate = "2026-01-01";
     await models.Certificate.create({ issuer_wallet_address: ISSUER, student_wallet_address: STUDENT, title: "A", certificate_hash: "h1", token_id: "1", issue_date: issueDate });
     await models.Certificate.create({ issuer_wallet_address: ISSUER, student_wallet_address: STUDENT, title: "B", certificate_hash: "h2", token_id: "2", issue_date: issueDate });
+    // Neither of these counts towards the public total.
+    await models.Certificate.create({ issuer_wallet_address: ISSUER, student_wallet_address: STUDENT, title: "Revocado", certificate_hash: "h3", token_id: "3", issue_date: issueDate, is_revoked: true });
+    await models.Certificate.create({ issuer_wallet_address: ISSUER, student_wallet_address: STUDENT, title: "Reservado", status: "pending" });
   });
 
   afterAll(() => sequelize.close());
@@ -98,6 +101,13 @@ describe("getPublicStudentProfile", () => {
       total_certificates: 2,
       joined_at: expect.anything(),
     });
+  });
+
+  test("total_certificates skips revoked and still-pending certificates", async () => {
+    const result = await getPublicStudentProfile({ models, walletAddress: STUDENT });
+    // 4 rows exist for this student: 2 issued, 1 revoked, 1 reserved.
+    expect(await models.Certificate.count({ where: { student_wallet_address: STUDENT } })).toBe(4);
+    expect(result.data.student.total_certificates).toBe(2);
   });
 
   test("never exposes the student email at any level", async () => {

--- a/backend/usecases/students/__tests__/getPublicStudentProfile.test.js
+++ b/backend/usecases/students/__tests__/getPublicStudentProfile.test.js
@@ -1,0 +1,114 @@
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+const { getPublicStudentProfile } = require("../getPublicStudentProfile");
+
+jest.setTimeout(15000);
+
+const STUDENT = "0x" + "aa".repeat(20);
+const ISSUER = "0x" + "bb".repeat(20);
+
+describe("getPublicStudentProfile", () => {
+  let sequelize, models;
+
+  beforeAll(async () => {
+    // Single-connection pool so PRAGMA foreign_keys = OFF survives across every
+    // query — Student.wallet_address isn't unique, which SQLite (unlike Postgres)
+    // requires for any FK pointing at it. Test-only; Postgres enforces FKs normally.
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    await sequelize.query("PRAGMA foreign_keys = OFF");
+
+    const { DataTypes } = SequelizePkg;
+    const User = require("../../../models/users")(sequelize, DataTypes);
+    const Issuer = require("../../../models/issuers")(sequelize, DataTypes);
+    const Student = require("../../../models/students")(sequelize, DataTypes);
+    // SQLite requires UNIQUE on any column referenced by a FK; the production
+    // Student model doesn't declare it (Postgres is more permissive).
+    Student.rawAttributes.wallet_address.unique = true;
+    const Recruiter = require("../../../models/recruiters")(sequelize, DataTypes);
+    const Certificate = require("../../../models/certificates")(sequelize, DataTypes);
+    const UserSession = require("../../../models/userSessions")(sequelize, DataTypes);
+
+    models = { User, Issuer, Student, Recruiter, Certificate, UserSession, sequelize, Sequelize: SequelizePkg };
+    Object.values(models).forEach((m) => m?.associate && m.associate(models));
+    await sequelize.sync({ force: true });
+
+    const nonce = () => crypto.randomBytes(16).toString("hex");
+    await models.User.create({
+      wallet_address: STUDENT,
+      role: "student",
+      name: "Ana",
+      lastname: "Perez",
+      email: "ana@example.com",
+      nonce: nonce(),
+    });
+    await models.Student.create({
+      wallet_address: STUDENT,
+      field_of_study: "Ciberseguridad",
+      bio: "Talento en formacion",
+      knowledge_areas: ["Rust", "Penetration Testing"],
+      github_url: "https://github.com/ana",
+      share_count: 4,
+    });
+
+    await models.User.create({ wallet_address: ISSUER, role: "issuer", name: "Prof", nonce: nonce() });
+    await models.Issuer.create({ wallet_address: ISSUER, organization_name: "HackAcademy" });
+
+    const issueDate = "2026-01-01";
+    await models.Certificate.create({ issuer_wallet_address: ISSUER, student_wallet_address: STUDENT, title: "A", certificate_hash: "h1", token_id: "1", issue_date: issueDate });
+    await models.Certificate.create({ issuer_wallet_address: ISSUER, student_wallet_address: STUDENT, title: "B", certificate_hash: "h2", token_id: "2", issue_date: issueDate });
+  });
+
+  afterAll(() => sequelize.close());
+
+  test("throws TypeError when models or walletAddress is missing", async () => {
+    await expect(getPublicStudentProfile({ walletAddress: STUDENT })).rejects.toThrow(TypeError);
+  });
+
+  test("returns INVALID_WALLET_ADDRESS for a malformed wallet", async () => {
+    const result = await getPublicStudentProfile({ models, walletAddress: "not-a-wallet" });
+    expect(result.code).toBe("INVALID_WALLET_ADDRESS");
+    expect(result.httpStatus).toBe(400);
+  });
+
+  test("returns STUDENT_NOT_FOUND for an unknown wallet", async () => {
+    const result = await getPublicStudentProfile({ models, walletAddress: "0x" + "ff".repeat(20) });
+    expect(result.code).toBe("STUDENT_NOT_FOUND");
+    expect(result.httpStatus).toBe(404);
+  });
+
+  test("returns the public profile with the certificate count", async () => {
+    const result = await getPublicStudentProfile({ models, walletAddress: STUDENT });
+    expect(result.ok).toBe(true);
+    expect(result.data.student).toEqual({
+      wallet_address: STUDENT,
+      name: "Ana",
+      lastname: "Perez",
+      field_of_study: "Ciberseguridad",
+      photo_url: null,
+      bio: "Talento en formacion",
+      knowledge_areas: ["Rust", "Penetration Testing"],
+      github_url: "https://github.com/ana",
+      linkedin_url: null,
+      twitter_url: null,
+      instagram_url: null,
+      share_count: 4,
+      total_certificates: 2,
+      joined_at: expect.anything(),
+    });
+  });
+
+  test("never exposes the student email at any level", async () => {
+    const result = await getPublicStudentProfile({ models, walletAddress: STUDENT });
+    expect(JSON.stringify(result.data)).not.toContain("ana@example.com");
+    expect(result.data.student).not.toHaveProperty("email");
+  });
+
+  test("accepts an uppercase wallet and normalizes it", async () => {
+    const result = await getPublicStudentProfile({ models, walletAddress: STUDENT.toUpperCase().replace("0X", "0x") });
+    expect(result.ok).toBe(true);
+    expect(result.data.student.wallet_address).toBe(STUDENT);
+  });
+});

--- a/backend/usecases/students/__tests__/updateOwnStudentProfile.test.js
+++ b/backend/usecases/students/__tests__/updateOwnStudentProfile.test.js
@@ -1,0 +1,163 @@
+const SequelizePkg = require("sequelize");
+const crypto = require("crypto");
+const { updateOwnStudentProfile } = require("../updateOwnStudentProfile");
+
+jest.setTimeout(15000);
+
+const STUDENT = "0x" + "aa".repeat(20);
+
+describe("updateOwnStudentProfile", () => {
+  let sequelize, models;
+
+  beforeAll(async () => {
+    sequelize = new SequelizePkg.Sequelize("sqlite::memory:", {
+      logging: false,
+      pool: { max: 1, min: 1, idle: Infinity, evict: false },
+    });
+    await sequelize.query("PRAGMA foreign_keys = OFF");
+
+    const { DataTypes } = SequelizePkg;
+    const User = require("../../../models/users")(sequelize, DataTypes);
+    const Issuer = require("../../../models/issuers")(sequelize, DataTypes);
+    const Student = require("../../../models/students")(sequelize, DataTypes);
+    // SQLite requires UNIQUE on any column referenced by a FK; the production
+    // Student model doesn't declare it (Postgres is more permissive).
+    Student.rawAttributes.wallet_address.unique = true;
+    const Recruiter = require("../../../models/recruiters")(sequelize, DataTypes);
+    const Certificate = require("../../../models/certificates")(sequelize, DataTypes);
+    const UserSession = require("../../../models/userSessions")(sequelize, DataTypes);
+
+    models = { User, Issuer, Student, Recruiter, Certificate, UserSession, sequelize, Sequelize: SequelizePkg };
+    Object.values(models).forEach((m) => m?.associate && m.associate(models));
+  });
+
+  afterAll(() => sequelize.close());
+
+  beforeEach(async () => {
+    await sequelize.sync({ force: true });
+    await models.User.create({
+      wallet_address: STUDENT,
+      role: "student",
+      name: "Ana",
+      email: "ana@example.com",
+      nonce: crypto.randomBytes(16).toString("hex"),
+    });
+    await models.Student.create({ wallet_address: STUDENT, field_of_study: "Ciberseguridad" });
+  });
+
+  test("throws TypeError when models or wallet is missing", async () => {
+    await expect(updateOwnStudentProfile({ wallet: STUDENT })).rejects.toThrow(TypeError);
+  });
+
+  test("returns INVALID_BIO when bio is not a string", async () => {
+    const result = await updateOwnStudentProfile({ models, wallet: STUDENT, bio: 42 });
+    expect(result.code).toBe("INVALID_BIO");
+    expect(result.httpStatus).toBe(400);
+  });
+
+  test("returns BIO_TOO_LONG past 500 characters", async () => {
+    const result = await updateOwnStudentProfile({ models, wallet: STUDENT, bio: "x".repeat(501) });
+    expect(result.code).toBe("BIO_TOO_LONG");
+  });
+
+  test("returns INVALID_KNOWLEDGE_AREAS when not an array", async () => {
+    const result = await updateOwnStudentProfile({ models, wallet: STUDENT, knowledgeAreas: "Rust" });
+    expect(result.code).toBe("INVALID_KNOWLEDGE_AREAS");
+  });
+
+  test("returns TOO_MANY_KNOWLEDGE_AREAS past 5 entries", async () => {
+    const result = await updateOwnStudentProfile({
+      models,
+      wallet: STUDENT,
+      knowledgeAreas: ["a", "b", "c", "d", "e", "f"],
+    });
+    expect(result.code).toBe("TOO_MANY_KNOWLEDGE_AREAS");
+  });
+
+  test("returns INVALID_KNOWLEDGE_AREA for a non-string or overlong entry", async () => {
+    const result = await updateOwnStudentProfile({ models, wallet: STUDENT, knowledgeAreas: ["ok", "x".repeat(101)] });
+    expect(result.code).toBe("INVALID_KNOWLEDGE_AREA");
+  });
+
+  test("returns INVALID_FIELD_OF_STUDY past 255 characters", async () => {
+    const result = await updateOwnStudentProfile({ models, wallet: STUDENT, fieldOfStudy: "x".repeat(256) });
+    expect(result.code).toBe("INVALID_FIELD_OF_STUDY");
+  });
+
+  test("rejects a non-https social link", async () => {
+    const result = await updateOwnStudentProfile({ models, wallet: STUDENT, githubUrl: "http://github.com/ana" });
+    expect(result.code).toBe("INVALID_GITHUB_URL");
+    expect(result.message).toBe("github_url must be a valid https:// URL");
+  });
+
+  test("reports the right code per social field", async () => {
+    const linkedin = await updateOwnStudentProfile({ models, wallet: STUDENT, linkedinUrl: "not-a-url" });
+    expect(linkedin.code).toBe("INVALID_LINKEDIN_URL");
+    const twitter = await updateOwnStudentProfile({ models, wallet: STUDENT, twitterUrl: "not-a-url" });
+    expect(twitter.code).toBe("INVALID_TWITTER_URL");
+    const instagram = await updateOwnStudentProfile({ models, wallet: STUDENT, instagramUrl: "not-a-url" });
+    expect(instagram.code).toBe("INVALID_INSTAGRAM_URL");
+  });
+
+  test("returns STUDENT_NOT_FOUND for an unknown wallet", async () => {
+    const result = await updateOwnStudentProfile({ models, wallet: "0x" + "ff".repeat(20), bio: "hi" });
+    expect(result.code).toBe("STUDENT_NOT_FOUND");
+    expect(result.httpStatus).toBe(404);
+  });
+
+  test("updates every writable field and trims strings", async () => {
+    const result = await updateOwnStudentProfile({
+      models,
+      wallet: STUDENT,
+      bio: "  Talento en formacion  ",
+      knowledgeAreas: ["Rust", "Penetration Testing"],
+      fieldOfStudy: "  Ingenieria  ",
+      githubUrl: "https://github.com/ana",
+      linkedinUrl: "https://linkedin.com/in/ana",
+      twitterUrl: "https://x.com/ana",
+      instagramUrl: "https://instagram.com/ana",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({
+      message: "Profile updated",
+      student: {
+        wallet_address: STUDENT,
+        field_of_study: "Ingenieria",
+        photo_url: null,
+        bio: "Talento en formacion",
+        knowledge_areas: ["Rust", "Penetration Testing"],
+        github_url: "https://github.com/ana",
+        linkedin_url: "https://linkedin.com/in/ana",
+        twitter_url: "https://x.com/ana",
+        instagram_url: "https://instagram.com/ana",
+      },
+    });
+  });
+
+  test("leaves untouched fields alone on a partial update", async () => {
+    await updateOwnStudentProfile({ models, wallet: STUDENT, bio: "primera" });
+    await updateOwnStudentProfile({ models, wallet: STUDENT, githubUrl: "https://github.com/ana" });
+
+    const student = await models.Student.findOne({ where: { wallet_address: STUDENT } });
+    expect(student.bio).toBe("primera");
+    expect(student.field_of_study).toBe("Ciberseguridad");
+  });
+
+  test("accepts null to clear a social link and the bio", async () => {
+    await updateOwnStudentProfile({ models, wallet: STUDENT, githubUrl: "https://github.com/ana", bio: "algo" });
+    const result = await updateOwnStudentProfile({ models, wallet: STUDENT, githubUrl: null, bio: null });
+
+    expect(result.ok).toBe(true);
+    expect(result.data.student.github_url).toBeNull();
+    expect(result.data.student.bio).toBeNull();
+  });
+
+  test("never writes to the User table", async () => {
+    await updateOwnStudentProfile({ models, wallet: STUDENT, bio: "hola", name: "Hacker", email: "evil@example.com" });
+
+    const user = await models.User.findOne({ where: { wallet_address: STUDENT } });
+    expect(user.name).toBe("Ana");
+    expect(user.email).toBe("ana@example.com");
+  });
+});

--- a/backend/usecases/students/getOwnStudentProfile.js
+++ b/backend/usecases/students/getOwnStudentProfile.js
@@ -1,0 +1,42 @@
+/**
+ * Reads the authenticated student's own full profile.
+ * Returns a result object — never throws on business errors.
+ */
+async function getOwnStudentProfile({ models, wallet }) {
+  if (!models || !wallet) {
+    throw new TypeError("getOwnStudentProfile requires { models, wallet }");
+  }
+
+  const student = await models.Student.findOne({
+    where: { wallet_address: wallet.toLowerCase() },
+    include: [{ model: models.User, attributes: ["name", "lastname", "email", "email_verified"] }],
+  });
+
+  if (!student) {
+    return { ok: false, code: "STUDENT_NOT_FOUND", httpStatus: 404, message: "Student not found" };
+  }
+
+  return {
+    ok: true,
+    data: {
+      wallet_address: student.wallet_address,
+      field_of_study: student.field_of_study,
+      photo_url: student.photo_url,
+      bio: student.bio,
+      knowledge_areas: student.knowledge_areas ?? [],
+      github_url: student.github_url,
+      linkedin_url: student.linkedin_url,
+      twitter_url: student.twitter_url,
+      instagram_url: student.instagram_url,
+      share_count: student.share_count,
+      // name/lastname/email are read-only here — they live on User and are not
+      // editable through PATCH /me (changing an email needs its own re-verification flow).
+      name: student.User?.name ?? null,
+      lastname: student.User?.lastname ?? null,
+      email: student.User?.email ?? null,
+      email_verified: student.User?.email_verified ?? false,
+    },
+  };
+}
+
+module.exports = { getOwnStudentProfile };

--- a/backend/usecases/students/getPublicStudentProfile.js
+++ b/backend/usecases/students/getPublicStudentProfile.js
@@ -1,0 +1,53 @@
+const WALLET_RE = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Reads a student's public profile (no email exposed).
+ * Returns a result object — never throws on business errors.
+ */
+async function getPublicStudentProfile({ models, walletAddress }) {
+  if (!models || !walletAddress) {
+    throw new TypeError("getPublicStudentProfile requires { models, walletAddress }");
+  }
+
+  const wallet = walletAddress.toLowerCase();
+  if (!WALLET_RE.test(wallet)) {
+    return { ok: false, code: "INVALID_WALLET_ADDRESS", httpStatus: 400, message: "Invalid wallet address" };
+  }
+
+  const student = await models.Student.findOne({
+    where: { wallet_address: wallet },
+    include: [{ model: models.User, attributes: ["name", "lastname", "created_at"] }],
+  });
+
+  if (!student) {
+    return { ok: false, code: "STUDENT_NOT_FOUND", httpStatus: 404, message: "Student not found" };
+  }
+
+  const totalCertificates = await models.Certificate.count({
+    where: { student_wallet_address: wallet },
+  });
+
+  return {
+    ok: true,
+    data: {
+      student: {
+        wallet_address: student.wallet_address,
+        name: student.User?.name || null,
+        lastname: student.User?.lastname || null,
+        field_of_study: student.field_of_study || null,
+        photo_url: student.photo_url || null,
+        bio: student.bio || null,
+        knowledge_areas: student.knowledge_areas || [],
+        github_url: student.github_url || null,
+        linkedin_url: student.linkedin_url || null,
+        twitter_url: student.twitter_url || null,
+        instagram_url: student.instagram_url || null,
+        share_count: student.share_count,
+        total_certificates: totalCertificates,
+        joined_at: student.User?.created_at || student.created_at,
+      },
+    },
+  };
+}
+
+module.exports = { getPublicStudentProfile };

--- a/backend/usecases/students/getPublicStudentProfile.js
+++ b/backend/usecases/students/getPublicStudentProfile.js
@@ -23,8 +23,11 @@ async function getPublicStudentProfile({ models, walletAddress }) {
     return { ok: false, code: "STUDENT_NOT_FOUND", httpStatus: 404, message: "Student not found" };
   }
 
+  // Public count a recruiter relies on: revoked certificates and ones still
+  // reserved (status 'pending', never minted on-chain) must not inflate it.
+  // Revoking only flips is_revoked and leaves status as 'issued', so both apply.
   const totalCertificates = await models.Certificate.count({
-    where: { student_wallet_address: wallet },
+    where: { student_wallet_address: wallet, is_revoked: false, status: "issued" },
   });
 
   return {

--- a/backend/usecases/students/updateOwnStudentProfile.js
+++ b/backend/usecases/students/updateOwnStudentProfile.js
@@ -1,0 +1,122 @@
+const MAX_BIO_LENGTH = 500;
+const MAX_KNOWLEDGE_AREAS = 5;
+const MAX_KNOWLEDGE_AREA_LENGTH = 100;
+const MAX_URL_LENGTH = 500;
+const MAX_FIELD_OF_STUDY_LENGTH = 255;
+const HTTPS_URL_RE = /^https:\/\/\S+$/;
+
+// Social links map 1:1 to columns; null clears the link, same as photo_url on the issuer side.
+const SOCIAL_FIELDS = [
+  { arg: "githubUrl", column: "github_url", code: "INVALID_GITHUB_URL", label: "github_url" },
+  { arg: "linkedinUrl", column: "linkedin_url", code: "INVALID_LINKEDIN_URL", label: "linkedin_url" },
+  { arg: "twitterUrl", column: "twitter_url", code: "INVALID_TWITTER_URL", label: "twitter_url" },
+  { arg: "instagramUrl", column: "instagram_url", code: "INVALID_INSTAGRAM_URL", label: "instagram_url" },
+];
+
+function validateBio(bio) {
+  if (bio === undefined || bio === null) return null;
+  if (typeof bio !== "string") {
+    return { ok: false, code: "INVALID_BIO", httpStatus: 400, message: "bio must be a string" };
+  }
+  if (bio.length > MAX_BIO_LENGTH) {
+    return { ok: false, code: "BIO_TOO_LONG", httpStatus: 400, message: "bio must be 500 characters or less" };
+  }
+  return null;
+}
+
+function validateKnowledgeAreas(knowledgeAreas) {
+  if (knowledgeAreas === undefined) return null;
+  if (!Array.isArray(knowledgeAreas)) {
+    return { ok: false, code: "INVALID_KNOWLEDGE_AREAS", httpStatus: 400, message: "knowledge_areas must be an array" };
+  }
+  if (knowledgeAreas.length > MAX_KNOWLEDGE_AREAS) {
+    return { ok: false, code: "TOO_MANY_KNOWLEDGE_AREAS", httpStatus: 400, message: "Maximum 5 knowledge areas allowed" };
+  }
+  if (knowledgeAreas.some((a) => typeof a !== "string" || a.length > MAX_KNOWLEDGE_AREA_LENGTH)) {
+    return {
+      ok: false,
+      code: "INVALID_KNOWLEDGE_AREA",
+      httpStatus: 400,
+      message: "Each knowledge area must be a string of max 100 characters",
+    };
+  }
+  return null;
+}
+
+function validateSocialUrl(value, { code, label }) {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string" || value.length > MAX_URL_LENGTH || !HTTPS_URL_RE.test(value.trim())) {
+    return { ok: false, code, httpStatus: 400, message: `${label} must be a valid https:// URL` };
+  }
+  return null;
+}
+
+function validateFieldOfStudy(fieldOfStudy) {
+  if (fieldOfStudy === undefined || fieldOfStudy === null) return null;
+  if (typeof fieldOfStudy !== "string" || fieldOfStudy.length > MAX_FIELD_OF_STUDY_LENGTH) {
+    return {
+      ok: false,
+      code: "INVALID_FIELD_OF_STUDY",
+      httpStatus: 400,
+      message: "field_of_study must be a string of max 255 characters",
+    };
+  }
+  return null;
+}
+
+/**
+ * Updates the authenticated student's own profile.
+ * Only columns on `students` are writable — name/lastname/email live on User and
+ * stay read-only (changing an email needs its own re-verification flow).
+ * Returns a result object — never throws on business errors.
+ */
+async function updateOwnStudentProfile({ models, wallet, ...fields }) {
+  if (!models || !wallet) {
+    throw new TypeError("updateOwnStudentProfile requires { models, wallet }");
+  }
+
+  const { bio, knowledgeAreas, fieldOfStudy } = fields;
+
+  const invalid =
+    validateBio(bio) ||
+    validateKnowledgeAreas(knowledgeAreas) ||
+    validateFieldOfStudy(fieldOfStudy) ||
+    SOCIAL_FIELDS.reduce((found, f) => found || validateSocialUrl(fields[f.arg], f), null);
+  if (invalid) return invalid;
+
+  const student = await models.Student.findOne({ where: { wallet_address: wallet.toLowerCase() } });
+  if (!student) {
+    return { ok: false, code: "STUDENT_NOT_FOUND", httpStatus: 404, message: "Student not found" };
+  }
+
+  const updates = {};
+  if (bio !== undefined) updates.bio = bio === null ? null : bio.trim();
+  if (knowledgeAreas !== undefined) updates.knowledge_areas = knowledgeAreas;
+  if (fieldOfStudy !== undefined) updates.field_of_study = fieldOfStudy === null ? null : fieldOfStudy.trim();
+  for (const f of SOCIAL_FIELDS) {
+    const value = fields[f.arg];
+    if (value !== undefined) updates[f.column] = value === null ? null : value.trim();
+  }
+
+  await student.update(updates);
+
+  return {
+    ok: true,
+    data: {
+      message: "Profile updated",
+      student: {
+        wallet_address: student.wallet_address,
+        field_of_study: student.field_of_study,
+        photo_url: student.photo_url,
+        bio: student.bio,
+        knowledge_areas: student.knowledge_areas,
+        github_url: student.github_url,
+        linkedin_url: student.linkedin_url,
+        twitter_url: student.twitter_url,
+        instagram_url: student.instagram_url,
+      },
+    },
+  };
+}
+
+module.exports = { updateOwnStudentProfile };


### PR DESCRIPTION
## Why

Segunda parte de mi tarea del ticket del perfil del talento. Da los tres endpoints que consume @Luis Soto desde `TalentProfile.tsx` y `EditTalentProfile.tsx`: perfil público, perfil propio y edición propia.

> **Base del PR:** apunta a `feat/student-profile-migration` (PR #103), no a `main`, para que el diff muestre solo lo de este bloque y no repita la migración. Cuando #103 se mergee, GitHub lo reapunta solo a `main`. Requiere que la migración esté corrida.

Decisiones ya confirmadas contigo en Discord: **no** refactorizo el resto de `routes/students.js` a usecases (queda para un ticket aparte), y el `PATCH /me` escribe **solo columnas de `students`** — `name`/`lastname`/`email` quedan de solo lectura, igual que en `updateOwnIssuerProfile.js`.

## What

**Usecases nuevos** (`backend/usecases/students/`, carpeta nueva; el patrón es el de `issuers` del PR #94):
- `getPublicStudentProfile.js` — valida y normaliza la wallet, y arma la respuesta campo a campo con whitelist explícita de atributos de `User` (`name`, `lastname`, `created_at`), así el email no puede filtrarse ni por accidente. `total_certificates` se cuenta en base de datos.
- `getOwnStudentProfile.js` — sí incluye `email` y `email_verified`.
- `updateOwnStudentProfile.js` — actualización parcial. Mismos límites y códigos de error que `updateOwnIssuerProfile` (bio 500, máximo 5 áreas de 100 caracteres) para que el front reciba contratos idénticos a los del educador. Las 4 redes aceptan una URL `https://` de hasta 500 caracteres o `null` para borrar el link, igual que `photo_url` del lado del educador.

**Rutas** (`backend/routes/students.js`):
- `GET /api/students/:wallet_address/public` — público, sin `authenticate`.
- `GET /api/students/me` y `PATCH /api/students/me` — autenticados, con guard de rol `student` (403 si no lo es).

⚠️ Las dos rutas `/me` se registran **antes** de `GET /:wallet_address`: si van después, Express captura `"me"` como `wallet_address`. El `DELETE /me` que ya existía no tenía el problema solo por ser otro verbo. Mismo criterio que `/featured` en `routes/issuers.js`.

**Ojo, dos endpoints parecidos que conviene no confundir:** el `GET /:wallet_address` que ya existía pide sesión y devuelve el objeto `user` completo; el `/:wallet_address/public` que agrego es anónimo y sin email. Quedaron documentados por separado en `documentacionAPI.md`.

**Doc**: los 3 endpoints en `documentacionAPI.md`, dentro de los commits de backend.

## Impact

Aditivo: tres rutas nuevas, ninguna existente se modifica ni cambia de contrato. Depende de la migración del PR #103.

Mandar `email`, `name` o `share_count` en el body del `PATCH` no tiene efecto — el usecase solo escribe columnas de `students`. Cambiar el email necesita su propio flujo de reverificación y queda fuera de este ticket.

@Fernando Anastasia: este PR toca `routes/students.js`, avisá antes de subir lo tuyo para no pisarnos en el merge. La extracción de la agregación de educadores sigue siendo tuya, no la toqué.

## Verification (local)

- **Tests nuevos: 37/37.** 24 de usecases (`usecases/students/__tests__/`, SQLite en memoria con modelos reales) + 13 de contrato HTTP (`tests/students-profile.test.js`, Supertest). Cubren `TypeError` por args faltantes, cada código de validación, 400/403/404 y los happy paths, más un test explícito de que el email no aparece en ningún nivel de la respuesta pública y otro de que el `PATCH` no escribe en `users`.
- **Suite completa: 994/1001.** Los 7 fallos son los preexistentes de siempre (`referralModels` ×5, `register`, `precheckCertificate`), iguales en `main`.
- **Verificación en vivo con `curl`** (backend en :3001 contra Postgres en Docker) — esta vez sí se pudo, armando a mano el schema que faltaba en local:
  - `GET /:wallet/public` → 200 con `total_certificates` correcto y sin email; 400 wallet mal formada; 404 inexistente; acepta la wallet en mayúsculas y la normaliza.
  - `GET /me` → 200 con email; 403 con un token de rol `issuer`; 401 sin sesión. Confirma también que `/me` no lo captura `/:wallet_address`.
  - `PATCH /me` → 200 y persiste en la DB (con `trim` aplicado); 400 bio de 501 caracteres; 400 con 6 áreas; 400 con una URL `http://`.
  - Mandando `{"email":"evil@example.com","name":"Hacker","share_count":999}` en el `PATCH`: responde 200 y en la DB `users.email`, `users.name` y `share_count` quedan intactos.
- `package-lock.json` sin diff.

**Detalle que salió del `curl` y que los tests con SQLite no mostraban:** el `GET /public` daba 500 hasta que creé la tabla `certificates` en el Postgres local — era el schema local incompleto, no el código. Sigue pendiente el dump de schema real que estaba armando Emmanuel; mientras tanto lo levanto a mano.
