### PR TITLE
feat(admin): auto-refresh dashboard lists and handle concurrent admin actions

### DIFF
--- a/frontend/src/pages/admin/AdminEducatorsPage.tsx
+++ b/frontend/src/pages/admin/AdminEducatorsPage.tsx
@@ -67,11 +67,25 @@ export default function AdminEducatorsPage() {
     queryKey: ['admin', 'educators', { tab, search, page, limit }],
     queryFn: () => adminApi.listEducators({ status: tab, search, page, limit }),
     placeholderData: (prev) => prev,
+    refetchInterval: 30_000,
   });
 
   function invalidate() {
     qc.invalidateQueries({ queryKey: ['admin', 'educators'] });
     qc.invalidateQueries({ queryKey: ['admin', 'stats'] });
+  }
+
+  // A 409 here means another admin already approved/rejected this row —
+  // the backend usecase is idempotent, so this is a stale-view race, not
+  // a real failure. Refresh instead of showing a generic error.
+  function handleConflictAwareError(err: unknown, fallbackTitle: string) {
+    if (err instanceof ApiServiceError && err.status === 409) {
+      toast({ title: 'Ya fue procesado por otro admin', description: 'Actualizando la lista…' });
+      invalidate();
+      return;
+    }
+    const msg = err instanceof ApiServiceError ? err.message : String(err);
+    toast({ title: fallbackTitle, description: msg, variant: 'destructive' });
   }
 
   const approveMutation = useMutation({
@@ -82,8 +96,8 @@ export default function AdminEducatorsPage() {
       invalidate();
     },
     onError: (err) => {
-      const msg = err instanceof ApiServiceError ? err.message : String(err);
-      toast({ title: 'No se pudo aprobar', description: msg, variant: 'destructive' });
+      setConfirmRow(null);
+      handleConflictAwareError(err, 'No se pudo aprobar');
     },
   });
 
@@ -97,8 +111,9 @@ export default function AdminEducatorsPage() {
       invalidate();
     },
     onError: (err) => {
-      const msg = err instanceof ApiServiceError ? err.message : String(err);
-      toast({ title: 'No se pudo rechazar', description: msg, variant: 'destructive' });
+      setRejectRow(null);
+      setRejectReason('');
+      handleConflictAwareError(err, 'No se pudo rechazar');
     },
   });
 

--- a/frontend/src/pages/admin/AdminPaymentsPage.tsx
+++ b/frontend/src/pages/admin/AdminPaymentsPage.tsx
@@ -72,6 +72,7 @@ export default function AdminPaymentsPage() {
       page, limit,
     }),
     placeholderData: (prev) => prev,
+    refetchInterval: 30_000,
   });
 
   const items = query.data?.items ?? [];

--- a/frontend/src/pages/admin/AdminTreasuryPage.tsx
+++ b/frontend/src/pages/admin/AdminTreasuryPage.tsx
@@ -72,6 +72,7 @@ export default function AdminTreasuryPage() {
     queryKey: ['admin', 'treasury', { tab, page, limit }],
     queryFn: () => adminApi.listTreasury({ status: tab, page, limit }),
     placeholderData: (prev) => prev,
+    refetchInterval: 30_000,
   });
 
   function invalidate() {
@@ -89,6 +90,16 @@ export default function AdminTreasuryPage() {
       invalidate();
     },
     onError: (err) => {
+      // A 409 (ALREADY_SENT/WRONG_STATE) means another admin already acted
+      // on this row — the usecase is idempotent, so refresh instead of
+      // showing a generic error.
+      if (err instanceof ApiServiceError && err.status === 409) {
+        toast({ title: 'Ya fue procesado por otro admin', description: 'Actualizando la lista…' });
+        setMarkRow(null);
+        setMarkHash('');
+        invalidate();
+        return;
+      }
       const msg = err instanceof ApiServiceError ? err.message : String(err);
       toast({ title: 'No se pudo registrar', description: msg, variant: 'destructive' });
     },


### PR DESCRIPTION
## Why

Con más de un admin (CTO + founder) usando el dashboard al mismo tiempo, las páginas de Educators, Payments y Treasury no se actualizaban solas — solo `AdminStatsPage` tenía polling. Si un admin aprobaba/rechazaba algo o marcaba un pago como enviado mientras otro tenía la misma lista abierta, el segundo veía datos desactualizados hasta que hiciera algo que disparara un refetch (cambiar de pestaña, recargar, cambiar de filtro).

No hay WebSockets ni infraestructura de push en este proyecto (se confirmó que el único "tiempo real" existente, `useCertificateEvents.ts`, conecta directo a un nodo público de Polygon, no a nuestro backend). Se evaluó agregar un servidor de WebSocket propio y se descartó por desproporcionado para 2-3 admins, dado que el backend ya es idempotente en estas mutaciones (devuelve 409 en `approveEducator`, `rejectEducator`, `markTreasurySent` si la acción ya se procesó).

## What

- `AdminEducatorsPage.tsx`, `AdminPaymentsPage.tsx`, `AdminTreasuryPage.tsx`: agregado `refetchInterval: 30_000`, mismo patrón que ya usaba `AdminStatsPage.tsx`.
- `AdminEducatorsPage.tsx` y `AdminTreasuryPage.tsx`: las mutaciones ahora detectan un 409 (`ApiServiceError.status === 409`) y muestran "Ya fue procesado por otro admin — actualizando la lista…" en vez de un error genérico, e invalidan las queries para reflejar el estado real.
- `AdminPaymentsPage.tsx` no tiene mutaciones (es de solo lectura), así que solo se agregó el polling.

No se tocó nada del backend — la idempotencia ya existía, esto solo hace que el frontend la maneje mejor.

## Impact

Las cuatro páginas de admin quedan sincronizadas dentro de una ventana de 30 segundos sin recargar la página. Cuando dos admins pisan la misma acción, el segundo ve un mensaje claro en vez de un error confuso, y la tabla se refresca sola al estado real.

## Test plan

- [x] Lint sobre los tres archivos tocados, sin errores.
- [ ] Probar con dos sesiones de admin abiertas en paralelo: aprobar un educator desde una y confirmar que la otra se actualiza sola dentro de 30s.
- [ ] Forzar un 409 (aprobar el mismo educator dos veces rápido desde dos pestañas) y confirmar el toast + refresco.